### PR TITLE
feat(ci): add Jira issue check on branches [AICC-32]

### DIFF
--- a/.github/workflows/branch-name-jira-check.yml
+++ b/.github/workflows/branch-name-jira-check.yml
@@ -1,0 +1,28 @@
+name: "📝 Branch Name Jira Check"
+
+on:
+  push:
+    # run on all branches except main/master
+    branches-ignore:
+      - main
+      - master
+
+jobs:
+  check-branch:
+    name: "🔍 Validate Branch Name"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - name: Validate branch name contains Jira ID
+        shell: bash
+        run: |
+          echo "🔖 Branch name: $BRANCH_NAME"
+          if [[ ! "$BRANCH_NAME" =~ \bAICC-[0-9]+\b ]]; then
+            echo "::error::❌ Branch name must include an AICC issue key (e.g. AICC-123)."
+            echo "::error::For example: feature/AICC-30-add-new-endpoint"
+            echo "::error::If you don’t have an AICC issue number yet, visit:"
+            echo "::error::  https://ai-content-curator.atlassian.net/jira/software/projects/AICC/list?sortBy=key&direction=DESC"
+            exit 1
+          fi


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`.github/workflows/branch-name-jira-check.yml`) that runs on every branch push (except `main`/`master`) and validates that the branch name contains a Jira issue key of the form `AICC-<number>`.  

If the branch name does not include a valid key, the job will fail with clear instructions:  
- Remind the user to include `AICC-<issue-number>` (e.g. `feature/AICC-30-add-new-endpoint`)  
- Point to the Jira board to create an issue if needed:  
  https://ai-content-curator.atlassian.net/jira/software/projects/AICC/list?sortBy=key&direction=DESC  

This helps ensure all branches are properly linked to our Jira tracking. 

[AICC-32]( 

---  
**Checklist:**  
- [x] New workflow file added under `.github/workflows/`  
- [x] Regex covers any branch including `AICC-<digits>`  
- [x] Fails fast with user-friendly error messages  
- [x] Documentation link to Jira board included