### PR TITLE
fix(crawler): fix crawler run issues [AICC-34]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .next
 frontend/test-results
 frontend/playwright-report
+backend/dist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SynthoraAI - AI-Powered Article Content Curator
 
-> [!TIP]
-> **SynthoraAI - Synthesizing the world’s news & information through AI.** 🚀✨
+> [!TIP] > **SynthoraAI - Synthesizing the world’s news & information through AI.** 🚀✨
 
 The **SynthoraAI - AI-Powered Article Content Curator** is a comprehensive, AI-powered system designed to aggregate, summarize, and present curated government-related articles.
 This monorepo, multi-services project is organized into four main components:

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   testMatch: [
     "**/__tests__/**/*.spec.ts",
     "**/__tests__/**/*.spec.js",
-    "**/?(*.)+(spec|test).[jt]s"
+    "**/?(*.)+(spec|test).[jt]s",
   ],
   globals: {
     "ts-jest": {

--- a/backend/src/__tests__/article.controller.spec.js
+++ b/backend/src/__tests__/article.controller.spec.js
@@ -48,9 +48,9 @@ describe("Article Controller", () => {
     it("200 returns data + count with default pagination", async () => {
       const chain = {
         select: jest.fn().mockReturnThis(),
-        sort:   jest.fn().mockReturnThis(),
-        skip:   jest.fn().mockReturnThis(),
-        limit:  jest.fn().mockResolvedValue(mockArticles),
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue(mockArticles),
       };
       Article.find.mockReturnValue(chain);
       Article.countDocuments.mockResolvedValue(mockCount);
@@ -64,15 +64,18 @@ describe("Article Controller", () => {
       expect(chain.skip).toHaveBeenCalledWith(0);
       expect(chain.limit).toHaveBeenCalledWith(10);
       expect(Article.countDocuments).toHaveBeenCalledWith({});
-      expect(res.json).toHaveBeenCalledWith({ data: mockArticles, total: mockCount });
+      expect(res.json).toHaveBeenCalledWith({
+        data: mockArticles,
+        total: mockCount,
+      });
     });
 
     it("200 applies source/topic filters & custom pagination", async () => {
       const chain = {
         select: jest.fn().mockReturnThis(),
-        sort:   jest.fn().mockReturnThis(),
-        skip:   jest.fn().mockReturnThis(),
-        limit:  jest.fn().mockResolvedValue(mockArticles),
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue(mockArticles),
       };
       Article.find.mockReturnValue(chain);
       Article.countDocuments.mockResolvedValue(mockCount);
@@ -80,9 +83,9 @@ describe("Article Controller", () => {
       req = {
         query: {
           source: "News",
-          topic:  "tech,health",
-          page:   "3",
-          limit:  "5",
+          topic: "tech,health",
+          page: "3",
+          limit: "5",
         },
       };
       await getArticles(req, res);
@@ -93,17 +96,24 @@ describe("Article Controller", () => {
       });
       expect(chain.skip).toHaveBeenCalledWith((3 - 1) * 5);
       expect(chain.limit).toHaveBeenCalledWith(5);
-      expect(res.json).toHaveBeenCalledWith({ data: mockArticles, total: mockCount });
+      expect(res.json).toHaveBeenCalledWith({
+        data: mockArticles,
+        total: mockCount,
+      });
     });
 
     it("500 on database error", async () => {
-      Article.find.mockImplementation(() => { throw new Error("DB fail"); });
+      Article.find.mockImplementation(() => {
+        throw new Error("DB fail");
+      });
 
       req = { query: {} };
       await getArticles(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to fetch articles" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to fetch articles",
+      });
     });
   });
 
@@ -136,7 +146,9 @@ describe("Article Controller", () => {
       await getArticleById(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to fetch article" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to fetch article",
+      });
     });
   });
 
@@ -158,7 +170,9 @@ describe("Article Controller", () => {
       await getArticleCount(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to fetch article count" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to fetch article count",
+      });
     });
   });
 
@@ -166,9 +180,9 @@ describe("Article Controller", () => {
     it("200 returns matching results", async () => {
       const chain = {
         select: jest.fn().mockReturnThis(),
-        sort:   jest.fn().mockReturnThis(),
-        skip:   jest.fn().mockReturnThis(),
-        limit:  jest.fn().mockResolvedValue(mockArticles),
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue(mockArticles),
       };
       Article.find.mockReturnValue(chain);
       Article.countDocuments.mockResolvedValue(mockCount);
@@ -178,24 +192,31 @@ describe("Article Controller", () => {
 
       expect(Article.find).toHaveBeenCalledWith({
         $or: [
-          { title:   { $regex: "foo", $options: "i" } },
+          { title: { $regex: "foo", $options: "i" } },
           { summary: { $regex: "foo", $options: "i" } },
-          { topics:  { $regex: "foo", $options: "i" } },
+          { topics: { $regex: "foo", $options: "i" } },
         ],
       });
       expect(chain.skip).toHaveBeenCalledWith((2 - 1) * 4);
       expect(chain.limit).toHaveBeenCalledWith(4);
-      expect(res.json).toHaveBeenCalledWith({ data: mockArticles, total: mockCount });
+      expect(res.json).toHaveBeenCalledWith({
+        data: mockArticles,
+        total: mockCount,
+      });
     });
 
     it("500 on error", async () => {
-      Article.find.mockImplementation(() => { throw new Error("fail"); });
+      Article.find.mockImplementation(() => {
+        throw new Error("fail");
+      });
 
       req = { query: {} };
       await searchArticles(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to search articles" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to search articles",
+      });
     });
   });
 
@@ -218,24 +239,29 @@ describe("Article Controller", () => {
       await getAllTopics(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to fetch topics" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to fetch topics",
+      });
     });
   });
 
   describe("getArticlesByTopic()", () => {
     it("200 aggregates and returns filtered articles", async () => {
       Article.aggregate
-        .mockResolvedValueOnce(mockArticles)            // first call: data
+        .mockResolvedValueOnce(mockArticles) // first call: data
         .mockResolvedValueOnce([{ total: mockCount }]); // second call: count
 
       req = {
         params: { topic: "SomeTopic" },
-        query:  { page: "2", limit: "3" },
+        query: { page: "2", limit: "3" },
       };
       await getArticlesByTopic(req, res);
 
       expect(Article.aggregate).toHaveBeenCalledTimes(2);
-      expect(res.json).toHaveBeenCalledWith({ data: mockArticles, total: mockCount });
+      expect(res.json).toHaveBeenCalledWith({
+        data: mockArticles,
+        total: mockCount,
+      });
     });
 
     it("500 on error", async () => {
@@ -245,7 +271,9 @@ describe("Article Controller", () => {
       await getArticlesByTopic(req, res);
 
       expect(statusMock).toHaveBeenCalledWith(500);
-      expect(jsonMock).toHaveBeenCalledWith({ error: "Failed to fetch articles by topic" });
+      expect(jsonMock).toHaveBeenCalledWith({
+        error: "Failed to fetch articles by topic",
+      });
     });
   });
 });

--- a/backend/src/__tests__/auth.controller.spec.js
+++ b/backend/src/__tests__/auth.controller.spec.js
@@ -48,7 +48,9 @@ describe("Auth Controller", () => {
   describe("register()", () => {
     it("400 if user already exists", async () => {
       User.findOne.mockResolvedValue({ _id: "exists" });
-      req = mockRequest({ body: { email: "a@b.com", password: "p", name: "N" } });
+      req = mockRequest({
+        body: { email: "a@b.com", password: "p", name: "N" },
+      });
       await register(req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalled();
@@ -57,10 +59,14 @@ describe("Auth Controller", () => {
     it("201 on successful registration", async () => {
       User.findOne.mockResolvedValue(null);
       bcrypt.hash = jest.fn().mockResolvedValue("hashedpass");
-      jest.spyOn(crypto, "randomBytes").mockReturnValue(Buffer.from("abcdef", "hex"));
+      jest
+        .spyOn(crypto, "randomBytes")
+        .mockReturnValue(Buffer.from("abcdef", "hex"));
       jwt.sign = jest.fn().mockReturnValue("jwt-token");
 
-      req = mockRequest({ body: { email: "a@b.com", password: "pw", name: "N" } });
+      req = mockRequest({
+        body: { email: "a@b.com", password: "pw", name: "N" },
+      });
       await register(req, res);
 
       expect(res.setHeader).toHaveBeenCalledWith("Authorization", "jwt-token");
@@ -70,7 +76,9 @@ describe("Auth Controller", () => {
 
     it("500 on internal error", async () => {
       User.findOne.mockRejectedValue(new Error("boom"));
-      req = mockRequest({ body: { email: "x@b.com", password: "pw", name: "X" } });
+      req = mockRequest({
+        body: { email: "x@b.com", password: "pw", name: "X" },
+      });
       await register(req, res);
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalled();
@@ -96,7 +104,13 @@ describe("Auth Controller", () => {
     });
 
     it("200 on successful login", async () => {
-      User.findOne.mockResolvedValue({ password: "hashed", _id: "u2", email: "a@b.com", name: "N", isVerified: true });
+      User.findOne.mockResolvedValue({
+        password: "hashed",
+        _id: "u2",
+        email: "a@b.com",
+        name: "N",
+        isVerified: true,
+      });
       bcrypt.compare = jest.fn().mockResolvedValue(true);
       jwt.sign = jest.fn().mockReturnValue("jwt-token-2");
       req = mockRequest({ body: { email: "a@b.com", password: "pw" } });
@@ -131,7 +145,11 @@ describe("Auth Controller", () => {
     });
 
     it("200 on success", async () => {
-      const user = { verificationToken: "tok", isVerified: false, save: jest.fn().mockResolvedValue(true) };
+      const user = {
+        verificationToken: "tok",
+        isVerified: false,
+        save: jest.fn().mockResolvedValue(true),
+      };
       User.findOne.mockResolvedValue(user);
       req = mockRequest({ query: { email: "x@x.com", token: "tok" } });
       await verifyEmail(req, res);
@@ -166,7 +184,9 @@ describe("Auth Controller", () => {
     it("200 on token gen", async () => {
       const user = { save: jest.fn().mockResolvedValue(true) };
       User.findOne.mockResolvedValue(user);
-      jest.spyOn(crypto, "randomBytes").mockReturnValue(Buffer.from("123456", "hex"));
+      jest
+        .spyOn(crypto, "randomBytes")
+        .mockReturnValue(Buffer.from("123456", "hex"));
       req = mockRequest({ body: { email: "x@x.com" } });
       await resetPasswordRequest(req, res);
       expect(user.save).toHaveBeenCalled();
@@ -192,7 +212,9 @@ describe("Auth Controller", () => {
 
     it("400 if invalid token/email", async () => {
       User.findOne.mockResolvedValue(null);
-      req = mockRequest({ body: { email: "a@b.com", token: "tkn", newPassword: "np" } });
+      req = mockRequest({
+        body: { email: "a@b.com", token: "tkn", newPassword: "np" },
+      });
       await confirmResetPassword(req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalled();
@@ -202,7 +224,9 @@ describe("Auth Controller", () => {
       const user = { save: jest.fn().mockResolvedValue(true) };
       bcrypt.hash = jest.fn().mockResolvedValue("newHash");
       User.findOne.mockResolvedValue(user);
-      req = mockRequest({ body: { email: "a@b.com", token: "tkn", newPassword: "np" } });
+      req = mockRequest({
+        body: { email: "a@b.com", token: "tkn", newPassword: "np" },
+      });
       await confirmResetPassword(req, res);
       expect(user.save).toHaveBeenCalled();
       expect(res.json).toHaveBeenCalled();
@@ -210,7 +234,9 @@ describe("Auth Controller", () => {
 
     it("500 on internal error", async () => {
       User.findOne.mockRejectedValue(new Error("boom"));
-      req = mockRequest({ body: { email: "a@b.com", token: "tkn", newPassword: "np" } });
+      req = mockRequest({
+        body: { email: "a@b.com", token: "tkn", newPassword: "np" },
+      });
       await confirmResetPassword(req, res);
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalled();

--- a/backend/src/__tests__/chat.controller.spec.js
+++ b/backend/src/__tests__/chat.controller.spec.js
@@ -1,14 +1,18 @@
 // 1. Mock @google/generative-ai so askGemini uses our stubbed model
 const sendMessageMock = jest.fn();
-const startChatMock = jest.fn().mockReturnValue({ sendMessage: sendMessageMock });
-const getGenerativeModelMock = jest.fn().mockReturnValue({ startChat: startChatMock });
+const startChatMock = jest
+  .fn()
+  .mockReturnValue({ sendMessage: sendMessageMock });
+const getGenerativeModelMock = jest
+  .fn()
+  .mockReturnValue({ startChat: startChatMock });
 const GoogleGenerativeAI = jest.fn().mockImplementation(() => ({
   getGenerativeModel: getGenerativeModelMock,
 }));
 
 jest.mock("@google/generative-ai", () => ({
   GoogleGenerativeAI,
-  GenerationConfig: {},         // not used in tests
+  GenerationConfig: {}, // not used in tests
   HarmCategory: { HARASSMENT: 0 },
   HarmBlockThreshold: { BLOCK_NONE: 0 },
 }));
@@ -36,14 +40,18 @@ describe("chat.controller – handleChat", () => {
     // missing both
     await handleChat(req, res, next);
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: "`article` and `userMessage` are required." });
+    expect(res.json).toHaveBeenCalledWith({
+      error: "`article` and `userMessage` are required.",
+    });
 
     // missing userMessage only
     req.body.article = { title: "T", content: "C" };
     req.body.userMessage = undefined;
     await handleChat(req, res, next);
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: "`article` and `userMessage` are required." });
+    expect(res.json).toHaveBeenCalledWith({
+      error: "`article` and `userMessage` are required.",
+    });
   });
 
   it("invokes askGemini and returns reply on success", async () => {

--- a/backend/src/__tests__/comment.controller.spec.js
+++ b/backend/src/__tests__/comment.controller.spec.js
@@ -2,11 +2,11 @@ const { Types } = require("mongoose");
 
 jest.mock("../models/comment.model", () => {
   const C = jest.fn().mockImplementation(() => ({
-    save:     jest.fn().mockResolvedValue(true),
-    remove:   jest.fn().mockResolvedValue(true),
-    populate: jest.fn().mockResolvedValue(null)
+    save: jest.fn().mockResolvedValue(true),
+    remove: jest.fn().mockResolvedValue(true),
+    populate: jest.fn().mockResolvedValue(null),
   }));
-  C.find     = jest.fn();
+  C.find = jest.fn();
   C.findById = jest.fn();
   return C;
 });
@@ -18,14 +18,14 @@ const {
   addComment,
   updateComment,
   deleteComment,
-  voteComment
+  voteComment,
 } = require("../controllers/comment.controller");
 
 const mkRes = () => {
   const r = {};
   r.status = jest.fn().mockReturnValue(r);
-  r.json   = jest.fn().mockReturnValue(r);
-  r.send   = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  r.send = jest.fn().mockReturnValue(r);
   return r;
 };
 
@@ -35,7 +35,9 @@ describe("comment controller – success paths only", () => {
   it("getCommentsByArticle 200", async () => {
     const docs = [{ _id: "c1" }];
     Comment.find.mockReturnValue({
-      populate: () => ({ populate: () => ({ sort: () => Promise.resolve(docs) }) })
+      populate: () => ({
+        populate: () => ({ sort: () => Promise.resolve(docs) }),
+      }),
     });
     const req = { params: { articleId: Types.ObjectId().toHexString() } };
     const res = mkRes();
@@ -46,7 +48,9 @@ describe("comment controller – success paths only", () => {
   it("getAllComments 200", async () => {
     const docs = [{ _id: "c2" }];
     Comment.find.mockReturnValue({
-      populate: () => ({ populate: () => ({ sort: () => Promise.resolve(docs) }) })
+      populate: () => ({
+        populate: () => ({ sort: () => Promise.resolve(docs) }),
+      }),
     });
     const res = mkRes();
     await getAllComments({}, res);
@@ -55,13 +59,13 @@ describe("comment controller – success paths only", () => {
 
   it("addComment 201", async () => {
     const fake = {};
-    fake.save     = jest.fn().mockResolvedValue(true);
+    fake.save = jest.fn().mockResolvedValue(true);
     fake.populate = jest.fn().mockResolvedValue(fake);
     Comment.mockImplementation(() => fake);
     const req = {
-      user:   { id: Types.ObjectId().toHexString() },
+      user: { id: Types.ObjectId().toHexString() },
       params: { articleId: Types.ObjectId().toHexString() },
-      body:   { content: "hi" }
+      body: { content: "hi" },
     };
     const res = mkRes();
     await addComment(req, res);
@@ -70,13 +74,16 @@ describe("comment controller – success paths only", () => {
   });
 
   it("updateComment 200", async () => {
-    const inst = { user:{ toHexString:()=> "u" }, save:jest.fn().mockResolvedValue(true) };
+    const inst = {
+      user: { toHexString: () => "u" },
+      save: jest.fn().mockResolvedValue(true),
+    };
     inst.populate = jest.fn().mockResolvedValue(inst);
     Comment.findById.mockResolvedValue(inst);
     const req = {
-      user:{ id:"u" },
-      params:{ id:Types.ObjectId().toHexString() },
-      body:{ content:"ok" }
+      user: { id: "u" },
+      params: { id: Types.ObjectId().toHexString() },
+      body: { content: "ok" },
     };
     const res = mkRes();
     await updateComment(req, res);
@@ -84,11 +91,14 @@ describe("comment controller – success paths only", () => {
   });
 
   it("deleteComment 204", async () => {
-    const inst = { user:{ toHexString:()=> "u" }, remove:jest.fn().mockResolvedValue(true) };
+    const inst = {
+      user: { toHexString: () => "u" },
+      remove: jest.fn().mockResolvedValue(true),
+    };
     Comment.findById.mockResolvedValue(inst);
     const req = {
-      user:{ id:"u" },
-      params:{ id:Types.ObjectId().toHexString() }
+      user: { id: "u" },
+      params: { id: Types.ObjectId().toHexString() },
     };
     const res = mkRes();
     await deleteComment(req, res);
@@ -97,17 +107,17 @@ describe("comment controller – success paths only", () => {
 
   it("voteComment upvote 200", async () => {
     const inst = {
-      user:{ toHexString:()=> "u" },
-      upvotes:{ pull:jest.fn(), addToSet:jest.fn() },
-      downvotes:{ pull:jest.fn(), addToSet:jest.fn() },
-      save:jest.fn().mockResolvedValue(true)
+      user: { toHexString: () => "u" },
+      upvotes: { pull: jest.fn(), addToSet: jest.fn() },
+      downvotes: { pull: jest.fn(), addToSet: jest.fn() },
+      save: jest.fn().mockResolvedValue(true),
     };
     inst.populate = jest.fn().mockResolvedValue(inst);
     Comment.findById.mockResolvedValue(inst);
     const req = {
-      user:{ id:"u" },
-      params:{ id:Types.ObjectId().toHexString() },
-      body:{ value:1 }
+      user: { id: "u" },
+      params: { id: Types.ObjectId().toHexString() },
+      body: { value: 1 },
     };
     const res = mkRes();
     await voteComment(req, res);

--- a/backend/src/__tests__/newsletter.controller.spec.js
+++ b/backend/src/__tests__/newsletter.controller.spec.js
@@ -7,7 +7,10 @@ jest.mock("../models/newsletterSubscriber.model", () => ({
 const NewsletterSubscriber = require("../models/newsletterSubscriber.model");
 
 // 2) Import the controller
-const { subscribe, unsubscribe } = require("../controllers/newsletter.controller");
+const {
+  subscribe,
+  unsubscribe,
+} = require("../controllers/newsletter.controller");
 
 describe("Newsletter Controller", () => {
   let req, res, statusMock, jsonMock;
@@ -40,7 +43,9 @@ describe("Newsletter Controller", () => {
       NewsletterSubscriber.findOne.mockResolvedValue({}); // simulate exists
       req = { body: { email: "x@y.com" } };
       await subscribe(req, res);
-      expect(NewsletterSubscriber.findOne).toHaveBeenCalledWith({ email: "x@y.com" });
+      expect(NewsletterSubscriber.findOne).toHaveBeenCalledWith({
+        email: "x@y.com",
+      });
       expect(statusMock).toHaveBeenCalledWith(200);
       expect(jsonMock).toHaveBeenCalled();
     });
@@ -50,8 +55,12 @@ describe("Newsletter Controller", () => {
       NewsletterSubscriber.create.mockResolvedValue({});
       req = { body: { email: "NEW@Y.COM" } };
       await subscribe(req, res);
-      expect(NewsletterSubscriber.findOne).toHaveBeenCalledWith({ email: "new@y.com" });
-      expect(NewsletterSubscriber.create).toHaveBeenCalledWith({ email: "new@y.com" });
+      expect(NewsletterSubscriber.findOne).toHaveBeenCalledWith({
+        email: "new@y.com",
+      });
+      expect(NewsletterSubscriber.create).toHaveBeenCalledWith({
+        email: "new@y.com",
+      });
       expect(statusMock).toHaveBeenCalledWith(201);
       expect(jsonMock).toHaveBeenCalled();
     });
@@ -83,7 +92,9 @@ describe("Newsletter Controller", () => {
       NewsletterSubscriber.findOneAndDelete.mockResolvedValue(null);
       req = { method: "GET", body: {}, query: { email: "x@y.com" } };
       await unsubscribe(req, res);
-      expect(NewsletterSubscriber.findOneAndDelete).toHaveBeenCalledWith({ email: "x@y.com" });
+      expect(NewsletterSubscriber.findOneAndDelete).toHaveBeenCalledWith({
+        email: "x@y.com",
+      });
       expect(statusMock).toHaveBeenCalledWith(404);
       expect(jsonMock).toHaveBeenCalled();
     });
@@ -93,13 +104,17 @@ describe("Newsletter Controller", () => {
       req = { method: "POST", body: { email: "X@Y.COM" }, query: {} };
       await unsubscribe(req, res);
       // normalization lowercases back to "x@y.com"
-      expect(NewsletterSubscriber.findOneAndDelete).toHaveBeenCalledWith({ email: "x@y.com" });
+      expect(NewsletterSubscriber.findOneAndDelete).toHaveBeenCalledWith({
+        email: "x@y.com",
+      });
       expect(statusMock).toHaveBeenCalledWith(200);
       expect(jsonMock).toHaveBeenCalled();
     });
 
     it("500 on internal error", async () => {
-      NewsletterSubscriber.findOneAndDelete.mockRejectedValue(new Error("boom"));
+      NewsletterSubscriber.findOneAndDelete.mockRejectedValue(
+        new Error("boom"),
+      );
       req = { method: "GET", body: {}, query: { email: "x@y.com" } };
       await unsubscribe(req, res);
       expect(statusMock).toHaveBeenCalledWith(500);

--- a/backend/src/__tests__/user.controller.js
+++ b/backend/src/__tests__/user.controller.js
@@ -40,7 +40,9 @@ describe("Favorite Controller", () => {
       Article.find.mockResolvedValue(articles);
       req = { user: { id: "u1" } };
       await getFavoriteArticles(req, res);
-      expect(Article.find).toHaveBeenCalledWith({ _id: { $in: user.favorites } });
+      expect(Article.find).toHaveBeenCalledWith({
+        _id: { $in: user.favorites },
+      });
       expect(res.json).toHaveBeenCalledWith(articles);
     });
 
@@ -50,7 +52,10 @@ describe("Favorite Controller", () => {
       console.error = jest.fn();
       req = { user: { id: "u1" } };
       await getFavoriteArticles(req, res);
-      expect(console.error).toHaveBeenCalledWith("Error retrieving favorite articles:", err);
+      expect(console.error).toHaveBeenCalledWith(
+        "Error retrieving favorite articles:",
+        err,
+      );
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
     });
@@ -79,7 +84,10 @@ describe("Favorite Controller", () => {
       console.error = jest.fn();
       req = { user: { id: "u1" } };
       await getFavoriteArticleIds(req, res);
-      expect(console.error).toHaveBeenCalledWith("Error retrieving favorites:", err);
+      expect(console.error).toHaveBeenCalledWith(
+        "Error retrieving favorites:",
+        err,
+      );
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
     });
@@ -90,7 +98,9 @@ describe("Favorite Controller", () => {
       req = { body: {} };
       await toggleFavoriteArticle(req, res);
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ error: "Article ID is required" });
+      expect(res.json).toHaveBeenCalledWith({
+        error: "Article ID is required",
+      });
     });
 
     it("404 if user not found", async () => {
@@ -102,7 +112,10 @@ describe("Favorite Controller", () => {
     });
 
     it("unfavorites when already in list", async () => {
-      const user = { favorites: ["a1", "b"], save: jest.fn().mockResolvedValue(true) };
+      const user = {
+        favorites: ["a1", "b"],
+        save: jest.fn().mockResolvedValue(true),
+      };
       User.findById.mockResolvedValue(user);
       req = { user: { id: "u1" }, body: { articleId: "a1" } };
       await toggleFavoriteArticle(req, res);
@@ -114,7 +127,10 @@ describe("Favorite Controller", () => {
     });
 
     it("favorites when not already in list", async () => {
-      const user = { favorites: ["b"], save: jest.fn().mockResolvedValue(true) };
+      const user = {
+        favorites: ["b"],
+        save: jest.fn().mockResolvedValue(true),
+      };
       User.findById.mockResolvedValue(user);
       req = { user: { id: "u1" }, body: { articleId: "a1" } };
       await toggleFavoriteArticle(req, res);
@@ -131,7 +147,10 @@ describe("Favorite Controller", () => {
       console.error = jest.fn();
       req = { user: { id: "u1" }, body: { articleId: "a1" } };
       await toggleFavoriteArticle(req, res);
-      expect(console.error).toHaveBeenCalledWith("Error favoriting article:", err);
+      expect(console.error).toHaveBeenCalledWith(
+        "Error favoriting article:",
+        err,
+      );
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
     });
@@ -172,7 +191,9 @@ describe("Favorite Controller", () => {
       req = { user: { id: "u1" }, query: { page: "2", limit: "5" } };
       await searchFavoriteArticles(req, res);
 
-      expect(Article.find).toHaveBeenCalledWith({ _id: { $in: user.favorites } });
+      expect(Article.find).toHaveBeenCalledWith({
+        _id: { $in: user.favorites },
+      });
       expect(chain.skip).toHaveBeenCalledWith((2 - 1) * 5);
       expect(chain.limit).toHaveBeenCalledWith(5);
       expect(res.json).toHaveBeenCalledWith({ data: articles, total: 1 });
@@ -209,7 +230,9 @@ describe("Favorite Controller", () => {
     it("500 on error", async () => {
       const err = new Error("fail");
       User.findById.mockResolvedValue(user);
-      Article.find.mockImplementation(() => { throw err; });
+      Article.find.mockImplementation(() => {
+        throw err;
+      });
       req = { user: { id: "u1" }, query: {} };
       await searchFavoriteArticles(req, res);
       expect(res.status).toHaveBeenCalledWith(500);
@@ -235,11 +258,16 @@ describe("Favorite Controller", () => {
 
     it("500 on error", async () => {
       const err = new Error("oops");
-      User.find.mockImplementation(() => { throw err; });
+      User.find.mockImplementation(() => {
+        throw err;
+      });
       console.error = jest.fn();
       req = {};
       await getAllUsers(req, res);
-      expect(console.error).toHaveBeenCalledWith("Error retrieving all users:", err);
+      expect(console.error).toHaveBeenCalledWith(
+        "Error retrieving all users:",
+        err,
+      );
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
     });

--- a/crawler/__tests__/crawler.service.spec.js
+++ b/crawler/__tests__/crawler.service.spec.js
@@ -1,15 +1,15 @@
 // 1. Mock axios with a factory so axios.get is a jest.fn()
 jest.mock("axios", () => ({
   get: jest.fn(),
-}))
-const axios = require("axios")
+}));
+const axios = require("axios");
 
 // 2. Mock Chromium helper
 jest.mock("@sparticuz/chromium", () => ({
   executablePath: jest.fn().mockResolvedValue("/usr/bin/chrome"),
   headless: true,
   args: [],
-}))
+}));
 
 // 3. Mock puppeteer-core
 jest.mock("puppeteer-core", () => ({
@@ -17,33 +17,34 @@ jest.mock("puppeteer-core", () => ({
     newPage: async () => ({
       setUserAgent: jest.fn(),
       goto: jest.fn(),
-      content: jest.fn().mockResolvedValue(
-        '<html><head><title>DynamicTitle</title></head><body>dynamic body text</body></html>'
-      ),
+      content: jest
+        .fn()
+        .mockResolvedValue(
+          "<html><head><title>DynamicTitle</title></head><body>dynamic body text</body></html>",
+        ),
     }),
     close: jest.fn(),
   }),
-}))
+}));
 
 const {
   fetchStaticArticle,
   fetchDynamicArticle,
-} = require("../services/crawler.service")
+} = require("../services/crawler.service");
 
 describe("crawler.service", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
   test("fetchStaticArticle returns parsed object", async () => {
     // Arrange
     axios.get.mockResolvedValue({
-      data:
-        '<html><head><title>StaticTitle</title></head><body>static body text</body></html>',
-    })
+      data: "<html><head><title>StaticTitle</title></head><body>static body text</body></html>",
+    });
 
     // Act
-    const result = await fetchStaticArticle("https://static.example.com")
+    const result = await fetchStaticArticle("https://static.example.com");
 
     // Assert
     expect(axios.get).toHaveBeenCalledWith(
@@ -51,26 +52,26 @@ describe("crawler.service", () => {
       expect.objectContaining({
         headers: expect.any(Object),
         timeout: expect.any(Number),
-      })
-    )
+      }),
+    );
     expect(result).toMatchObject({
       url: "https://static.example.com",
       source: "https://static.example.com",
-    })
-    expect(result.title).toBe("StaticTitle")
-    expect(result.content).toContain("static body text")
-  })
+    });
+    expect(result.title).toBe("StaticTitle");
+    expect(result.content).toContain("static body text");
+  });
 
   test("fetchDynamicArticle returns parsed object", async () => {
     // Act
-    const result = await fetchDynamicArticle("https://dynamic.example.com")
+    const result = await fetchDynamicArticle("https://dynamic.example.com");
 
     // Assert
     expect(result).toMatchObject({
       url: "https://dynamic.example.com",
       source: "https://dynamic.example.com",
-    })
-    expect(result.title).toBe("DynamicTitle")
-    expect(result.content).toContain("dynamic body text")
-  })
-})
+    });
+    expect(result.title).toBe("DynamicTitle");
+    expect(result.content).toContain("dynamic body text");
+  });
+});

--- a/crawler/__tests__/extractTopics.spec.js
+++ b/crawler/__tests__/extractTopics.spec.js
@@ -1,38 +1,38 @@
-process.env.GOOGLE_AI_API_KEY  = "key1"
-process.env.GOOGLE_AI_API_KEY1 = "key2"
+process.env.GOOGLE_AI_API_KEY = "key1";
+process.env.GOOGLE_AI_API_KEY1 = "key2";
 
 jest.mock("@google/generative-ai", () => ({
   GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
     getGenerativeModel: () => ({
       generateContent: jest.fn().mockResolvedValue({
-        response: { text: () => "Alpha, Beta, gamma, alpha" }
-      })
-    })
+        response: { text: () => "Alpha, Beta, gamma, alpha" },
+      }),
+    }),
   })),
   HarmCategory: {
-    HARM_CATEGORY_HARASSMENT:           0,
-    HARM_CATEGORY_HATE_SPEECH:          1,
-    HARM_CATEGORY_SEXUALLY_EXPLICIT:    2,
-    HARM_CATEGORY_DANGEROUS_CONTENT:    3,
+    HARM_CATEGORY_HARASSMENT: 0,
+    HARM_CATEGORY_HATE_SPEECH: 1,
+    HARM_CATEGORY_SEXUALLY_EXPLICIT: 2,
+    HARM_CATEGORY_DANGEROUS_CONTENT: 3,
   },
   HarmBlockThreshold: {
     BLOCK_NONE: 0,
   },
   GenerationConfig: {}, // placeholder
-}))
+}));
 
-const { extractTopics } = require("../services/topicExtractor.service")
+const { extractTopics } = require("../services/topicExtractor.service");
 
 describe("extractTopics", () => {
   it("calls AI and returns cleaned, deduped topics", async () => {
-    const raw = "Some long text"
-    const topics = await extractTopics(raw)
-    expect(topics).toEqual(["alpha", "beta", "gamma"])
-  })
+    const raw = "Some long text";
+    const topics = await extractTopics(raw);
+    expect(topics).toEqual(["alpha", "beta", "gamma"]);
+  });
 
   it("truncates input over MAX_CONTENT_CHARS", async () => {
-    const longText = "x".repeat(5000)
-    const topics = await extractTopics(longText)
-    expect(topics).toEqual(["alpha", "beta", "gamma"])
-  })
-})
+    const longText = "x".repeat(5000);
+    const topics = await extractTopics(longText);
+    expect(topics).toEqual(["alpha", "beta", "gamma"]);
+  });
+});

--- a/crawler/__tests__/news.service.spec.js
+++ b/crawler/__tests__/news.service.spec.js
@@ -1,6 +1,6 @@
-const path = "../services/apiFetcher.service"
-const axios = { get: jest.fn() }
-jest.mock("axios", () => axios)
+const path = "../services/apiFetcher.service";
+const axios = { get: jest.fn() };
+jest.mock("axios", () => axios);
 
 const makeArticle = (url, t = "t") => ({
   url,
@@ -8,59 +8,77 @@ const makeArticle = (url, t = "t") => ({
   content: null,
   description: "desc",
   source: { name: "SRC" },
-})
+});
 
 /* utility to (re-)load the module with fresh env + mocks */
 const loadService = () => {
-  jest.resetModules()
-  delete process.env.NEWS_API_KEY
-  delete process.env.NEWS_API_KEY1
-  process.env.NEWS_API_KEY  = "k0"
-  process.env.NEWS_API_KEY1 = "k1"
-  return require(path)
-}
+  jest.resetModules();
+  delete process.env.NEWS_API_KEY;
+  delete process.env.NEWS_API_KEY1;
+  process.env.NEWS_API_KEY = "k0";
+  process.env.NEWS_API_KEY1 = "k1";
+  return require(path);
+};
 
 describe("fetchArticlesFromNewsAPI", () => {
-  afterEach(() => jest.clearAllMocks())
+  afterEach(() => jest.clearAllMocks());
 
   test("happy path – three pages, filters static/anchor urls", async () => {
-    const art1 = makeArticle("https://nytimes.com/good")
-    const artBadStatic = makeArticle("https://x.com/file.css")
-    const artBadAnchor = makeArticle("https://x.com/p#frag")
+    const art1 = makeArticle("https://nytimes.com/good");
+    const artBadStatic = makeArticle("https://x.com/file.css");
+    const artBadAnchor = makeArticle("https://x.com/p#frag");
 
-    const art2 = makeArticle("https://wp.com/ok2")
-    const art3 = makeArticle("https://wp.com/ok3")
+    const art2 = makeArticle("https://wp.com/ok2");
+    const art3 = makeArticle("https://wp.com/ok3");
 
     axios.get
       .mockResolvedValueOnce({
-        data: { totalResults: 250, articles: [art1, artBadStatic, artBadAnchor] },
+        data: {
+          totalResults: 250,
+          articles: [art1, artBadStatic, artBadAnchor],
+        },
       })
       .mockResolvedValueOnce({ data: { articles: [art2] } })
-      .mockResolvedValueOnce({ data: { articles: [art3] } })
+      .mockResolvedValueOnce({ data: { articles: [art3] } });
 
-    const { fetchArticlesFromNewsAPI } = loadService()
-    const out = await fetchArticlesFromNewsAPI()
+    const { fetchArticlesFromNewsAPI } = loadService();
+    const out = await fetchArticlesFromNewsAPI();
 
     expect(out).toEqual([
-      { url: art1.url, title: art1.title, content: art1.description, source: "SRC" },
-      { url: art2.url, title: art2.title, content: art2.description, source: "SRC" },
-      { url: art3.url, title: art3.title, content: art3.description, source: "SRC" },
-    ])
-    expect(axios.get).toHaveBeenCalledTimes(3)
-  })
+      {
+        url: art1.url,
+        title: art1.title,
+        content: art1.description,
+        source: "SRC",
+      },
+      {
+        url: art2.url,
+        title: art2.title,
+        content: art2.description,
+        source: "SRC",
+      },
+      {
+        url: art3.url,
+        title: art3.title,
+        content: art3.description,
+        source: "SRC",
+      },
+    ]);
+    expect(axios.get).toHaveBeenCalledTimes(3);
+  });
 
   test("key rotation on 401 then success", async () => {
     const err401 = Object.assign(new Error("unauth"), {
       response: { status: 401 },
-    })
+    });
     axios.get
-      .mockRejectedValueOnce(err401)                      // first key fails
-      .mockResolvedValueOnce({ data: { totalResults: 0, articles: [] } })
+      .mockRejectedValueOnce(err401) // first key fails
+      .mockResolvedValueOnce({ data: { totalResults: 0, articles: [] } });
 
-    const { fetchArticlesFromNewsAPI } = loadService()
-    const out = await fetchArticlesFromNewsAPI()
+    const { fetchArticlesFromNewsAPI } = loadService();
+    const out = await fetchArticlesFromNewsAPI();
 
-    expect(out).toEqual([])
-    expect(axios.get).toHaveBeenCalledTimes(2)            // rotated to second key
-  })
-})
+    expect(out).toEqual([]);
+    expect(axios.get).toHaveBeenCalledTimes(2); // rotated to second key
+  });
+});

--- a/crawler/__tests__/pipeline.helpers.spec.js
+++ b/crawler/__tests__/pipeline.helpers.spec.js
@@ -1,15 +1,15 @@
 // Mock axios to expose `get` as a jest.fn()
 jest.mock("axios", () => ({
-  get: jest.fn()
-}))
-const axios = require("axios")
+  get: jest.fn(),
+}));
+const axios = require("axios");
 
 // Mock @sparticuz/chromium
 jest.mock("@sparticuz/chromium", () => ({
   executablePath: jest.fn().mockResolvedValue("/usr/bin/chrome"),
   headless: true,
-  args: []
-}))
+  args: [],
+}));
 
 // Mock puppeteer-core
 jest.mock("puppeteer-core", () => ({
@@ -17,49 +17,53 @@ jest.mock("puppeteer-core", () => ({
     newPage: async () => ({
       setUserAgent: jest.fn(),
       goto: jest.fn(),
-      content: jest.fn().mockResolvedValue(
-        '<html><head><title>Dyn</title></head><body>dyn body</body></html>'
-      )
+      content: jest
+        .fn()
+        .mockResolvedValue(
+          "<html><head><title>Dyn</title></head><body>dyn body</body></html>",
+        ),
     }),
-    close: jest.fn()
-  })
-}))
+    close: jest.fn(),
+  }),
+}));
 
 const {
   fetchStaticArticle,
-  fetchDynamicArticle
-} = require("../services/crawler.service")
+  fetchDynamicArticle,
+} = require("../services/crawler.service");
 
 describe("crawler.service", () => {
   beforeEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
   test("fetchStaticArticle returns parsed object", async () => {
     axios.get.mockResolvedValue({
-      data:
-        '<html><head><title>Stat</title></head><body>static body</body></html>'
-    })
+      data: "<html><head><title>Stat</title></head><body>static body</body></html>",
+    });
 
-    const result = await fetchStaticArticle("https://static.test")
+    const result = await fetchStaticArticle("https://static.test");
 
-    expect(axios.get).toHaveBeenCalledWith("https://static.test", expect.any(Object))
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://static.test",
+      expect.any(Object),
+    );
     expect(result).toMatchObject({
       url: "https://static.test",
-      source: "https://static.test"
-    })
-    expect(result.title).toBe("Stat")
-    expect(result.content).toContain("static body")
-  })
+      source: "https://static.test",
+    });
+    expect(result.title).toBe("Stat");
+    expect(result.content).toContain("static body");
+  });
 
   test("fetchDynamicArticle returns parsed object", async () => {
-    const result = await fetchDynamicArticle("https://dynamic.test")
+    const result = await fetchDynamicArticle("https://dynamic.test");
 
     expect(result).toMatchObject({
       url: "https://dynamic.test",
-      source: "https://dynamic.test"
-    })
-    expect(result.title).toBe("Dyn")
-    expect(result.content).toContain("dyn body")
-  })
-})
+      source: "https://dynamic.test",
+    });
+    expect(result.title).toBe("Dyn");
+    expect(result.content).toContain("dyn body");
+  });
+});

--- a/crawler/__tests__/summarize.service.spec.js
+++ b/crawler/__tests__/summarize.service.spec.js
@@ -1,54 +1,58 @@
-const axios = { get: jest.fn() }
-jest.mock("axios", () => axios)
+const axios = { get: jest.fn() };
+jest.mock("axios", () => axios);
 
 jest.mock("@sparticuz/chromium", () => ({
   executablePath: jest.fn().mockResolvedValue("/bin/chrome"),
   headless: true,
-  args: []
-}))
+  args: [],
+}));
 
 jest.mock("puppeteer-core", () => ({
   launch: jest.fn().mockResolvedValue({
     newPage: async () => ({
       setUserAgent: jest.fn(),
       goto: jest.fn(),
-      content: jest.fn().mockResolvedValue(
-        '<html><head><title>Dyn</title></head><body>dyn body</body></html>'
-      )
+      content: jest
+        .fn()
+        .mockResolvedValue(
+          "<html><head><title>Dyn</title></head><body>dyn body</body></html>",
+        ),
     }),
-    close: jest.fn()
-  })
-}))
+    close: jest.fn(),
+  }),
+}));
 
-const { fetchStaticArticle, fetchDynamicArticle } = require("../services/crawler.service")
+const {
+  fetchStaticArticle,
+  fetchDynamicArticle,
+} = require("../services/crawler.service");
 
 describe("crawler service minimal", () => {
   beforeEach(() => {
-    axios.get.mockReset()
-  })
+    axios.get.mockReset();
+  });
 
   test("fetchStaticArticle returns parsed object", async () => {
     axios.get.mockResolvedValue({
-      data:
-        '<html><head><title>Stat</title></head><body>static body</body></html>'
-    })
+      data: "<html><head><title>Stat</title></head><body>static body</body></html>",
+    });
 
-    const out = await fetchStaticArticle("https://x.com")
+    const out = await fetchStaticArticle("https://x.com");
     expect(out).toMatchObject({
       url: "https://x.com",
-      source: "https://x.com"
-    })
-    expect(typeof out.title).toBe("string")
-    expect(out.content.includes("static body")).toBe(true)
-  })
+      source: "https://x.com",
+    });
+    expect(typeof out.title).toBe("string");
+    expect(out.content.includes("static body")).toBe(true);
+  });
 
   test("fetchDynamicArticle returns parsed object", async () => {
-    const out = await fetchDynamicArticle("https://y.com")
+    const out = await fetchDynamicArticle("https://y.com");
     expect(out).toMatchObject({
       url: "https://y.com",
-      source: "https://y.com"
-    })
-    expect(typeof out.title).toBe("string")
-    expect(out.content.includes("dyn body")).toBe(true)
-  })
-})
+      source: "https://y.com",
+    });
+    expect(typeof out.title).toBe("string");
+    expect(out.content.includes("dyn body")).toBe(true);
+  });
+});

--- a/crawler/jest.config.js
+++ b/crawler/jest.config.js
@@ -5,4 +5,4 @@ module.exports = {
   moduleFileExtensions: ["ts", "js", "json"],
   transform: { "^.+\\.ts$": ["ts-jest", { tsconfig: "tsconfig.json" }] },
   testMatch: ["**/__tests__/**/*.spec.(ts|js)"],
-}
+};

--- a/crawler/models/article.model.js
+++ b/crawler/models/article.model.js
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var mongoose_1 = require("mongoose");
+var articleSchema = new mongoose_1.Schema({
+  url: { type: String, required: true },
+  title: { type: String, required: true },
+  content: { type: String, required: true },
+  summary: { type: String },
+  topics: { type: [String], default: [] },
+  source: { type: String, required: true },
+  fetchedAt: { type: Date, default: Date.now },
+});
+// Set a custom toJSON transform to enforce key ordering
+articleSchema.set("toJSON", {
+  transform: function (doc, ret) {
+    return {
+      _id: ret._id,
+      url: ret.url,
+      title: ret.title,
+      content: ret.content,
+      summary: ret.summary,
+      topics: ret.topics,
+      source: ret.source,
+      fetchedAt: ret.fetchedAt,
+    };
+  },
+});
+var Article = (0, mongoose_1.model)("Article", articleSchema);
+exports.default = Article;

--- a/crawler/pages/api/scheduled/fetchAndSummarize.js
+++ b/crawler/pages/api/scheduled/fetchAndSummarize.js
@@ -1,0 +1,178 @@
+"use strict";
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+var fetchAndSummarize_1 = require("../../../schedule/fetchAndSummarize");
+/**
+ * This API route is scheduled to run every day at 9 AM UTC.
+ *
+ * @param req - The request object (not used).
+ * @param res - The response object to send the result.
+ */
+function handler(req, res) {
+  return __awaiter(this, void 0, void 0, function () {
+    var result, err_1;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          _a.trys.push([0, 2, , 3]);
+          return [4 /*yield*/, (0, fetchAndSummarize_1.fetchAndSummarize)()];
+        case 1:
+          result = _a.sent();
+          return [
+            2 /*return*/,
+            res.status(200).json({ status: "success", result: result }),
+          ];
+        case 2:
+          err_1 = _a.sent();
+          console.error("Error in scheduled function:", err_1);
+          return [
+            2 /*return*/,
+            res
+              .status(500)
+              .json({
+                status: "error",
+                message:
+                  (err_1 === null || err_1 === void 0
+                    ? void 0
+                    : err_1.message) || "Unknown error",
+              }),
+          ];
+        case 3:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+exports.default = handler;

--- a/crawler/schedule/fetchAndSummarize.js
+++ b/crawler/schedule/fetchAndSummarize.js
@@ -1,0 +1,629 @@
+#!/usr/bin/env ts-node
+"use strict";
+/**
+ * schedule/fetchAndSummarize.ts
+ *
+ * End‑to‑end pipeline:
+ *  1. Crawl homepages (BFS, depth/link bounded)
+ *  2. Pull headlines from NewsAPI
+ *  3. De‑dupe (DB + in‑process)
+ *  4. Fetch full article (static → dynamic)
+ *  5. Summarize + topic‑tag (key/model rotation)
+ *  6. Upsert into Mongo
+ */
+var __assign =
+  (this && this.__assign) ||
+  function () {
+    __assign =
+      Object.assign ||
+      function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+var __spreadArray =
+  (this && this.__spreadArray) ||
+  function (to, from, pack) {
+    if (pack || arguments.length === 2)
+      for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+          if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+          ar[i] = from[i];
+        }
+      }
+    return to.concat(ar || Array.prototype.slice.call(from));
+  };
+var _a, _b, _c, _d, _e, _f, _g, _h;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchAndSummarize = void 0;
+var mongoose_1 = require("mongoose");
+var dotenv = require("dotenv");
+var article_model_1 = require("../models/article.model");
+var crawler_service_1 = require("../services/crawler.service");
+var apiFetcher_service_1 = require("../services/apiFetcher.service");
+var summarization_service_1 = require("../services/summarization.service");
+var topicExtractor_service_1 = require("../services/topicExtractor.service");
+var logger_1 = require("../utils/logger");
+var cleanData_1 = require("../scripts/cleanData");
+dotenv.config();
+mongoose_1.default.set("strictQuery", false);
+/* ─────────────────── ENV / CONFIG ─────────────────── */
+var MONGODB_URI =
+  (_a = process.env.MONGODB_URI) !== null && _a !== void 0 ? _a : "";
+if (!MONGODB_URI) throw new Error("MONGODB_URI must be defined");
+var HOMEPAGE_URLS = (
+  (_b = process.env.CRAWL_URLS) !== null && _b !== void 0 ? _b : ""
+)
+  .split(",")
+  .map(function (u) {
+    return u.trim();
+  })
+  .filter(Boolean);
+var CRAWL_MAX_LINKS = parseInt(
+  (_c = process.env.CRAWL_MAX_LINKS) !== null && _c !== void 0 ? _c : "40",
+  10,
+);
+var CRAWL_MAX_DEPTH = parseInt(
+  (_d = process.env.CRAWL_MAX_DEPTH) !== null && _d !== void 0 ? _d : "2",
+  10,
+);
+var CRAWL_CONCURRENCY = parseInt(
+  (_e = process.env.CRAWL_CONCURRENCY) !== null && _e !== void 0 ? _e : "3",
+  10,
+);
+var FETCH_CONCURRENCY = parseInt(
+  (_f = process.env.FETCH_CONCURRENCY) !== null && _f !== void 0 ? _f : "5",
+  10,
+);
+var DELAY_BETWEEN_REQUESTS_MS = parseInt(
+  (_g = process.env.DELAY_BETWEEN_REQUESTS_MS) !== null && _g !== void 0
+    ? _g
+    : "1000",
+  10,
+);
+var MAX_FETCH_TIME_MS = parseInt(
+  (_h = process.env.MAX_FETCH_TIME_MS) !== null && _h !== void 0 ? _h : "60000",
+  10,
+);
+var STATIC_EXT_RE =
+  /\.(css|js|png|jpe?g|gif|svg|ico|webp|woff2?|eot|ttf|otf|json|webmanifest|xml|rss|atom|mp4|mpeg|mov|zip|gz|pdf)(\?|$)/i;
+var wait = function (ms) {
+  return new Promise(function (r) {
+    return setTimeout(r, ms);
+  });
+};
+/* ─────────────────── DUPLICATE‑SAFE UPSERT ─────────────────── */
+/**
+ * Upsert an article into the database.
+ * If the article already exists, it will be skipped.
+ *
+ * @param data - The article data to upsert.
+ */
+function upsertArticle(data) {
+  return __awaiter(this, void 0, void 0, function () {
+    var res;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          return [
+            4 /*yield*/,
+            article_model_1.default.updateOne(
+              { url: data.url },
+              {
+                $setOnInsert: __assign(__assign({}, data), {
+                  fetchedAt: new Date(),
+                }),
+              },
+              { upsert: true },
+            ),
+          ];
+        case 1:
+          res = _a.sent();
+          if (res.upsertedCount) {
+            logger_1.default.info(
+              "\u2705 Saved: ".concat(data.title || data.url),
+            );
+          } else {
+            logger_1.default.debug(
+              "\uD83D\uDD04 Skipped duplicate: ".concat(data.url),
+            );
+          }
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+/* ─────────────────── IN‑MEMORY CONCURRENCY GUARD ─────────────────── */
+var processingUrls = new Set();
+/**
+ * Start processing a URL. If it's already being processed, return false.
+ *
+ * @param url - The URL to process.
+ * @returns true if the URL is now being processed, false if it was already in process.
+ */
+function startProcessing(url) {
+  if (processingUrls.has(url)) return false;
+  processingUrls.add(url);
+  return true;
+}
+/**
+ * Mark a URL as done processing.
+ *
+ * @param url - The URL that has finished processing.
+ */
+function doneProcessing(url) {
+  processingUrls.delete(url);
+}
+/* ─────────────────── NEWS‑API ARTICLES ─────────────────── */
+/**
+ * Process an article from the NewsAPI.
+ *
+ * @param api - The article data from the API.
+ */
+function processApiArticle(api) {
+  var _a, _b, _c;
+  return __awaiter(this, void 0, void 0, function () {
+    var text, summary, topics, err_1;
+    return __generator(this, function (_d) {
+      switch (_d.label) {
+        case 0:
+          if (
+            STATIC_EXT_RE.test(api.url) ||
+            api.url.includes("#") ||
+            !startProcessing(api.url)
+          )
+            return [2 /*return*/];
+          _d.label = 1;
+        case 1:
+          _d.trys.push([1, 5, 6, 7]);
+          text = (api.content || api.description || "").trim();
+          if (!text) {
+            logger_1.default.warn(
+              "API article ".concat(api.url, " has no text"),
+            );
+            return [2 /*return*/];
+          }
+          return [
+            4 /*yield*/,
+            (0, summarization_service_1.summarizeContent)(text),
+          ];
+        case 2:
+          summary = _d.sent();
+          return [
+            4 /*yield*/,
+            (0, topicExtractor_service_1.extractTopics)(summary),
+          ];
+        case 3:
+          topics = _d.sent();
+          return [
+            4 /*yield*/,
+            upsertArticle({
+              url: api.url,
+              title:
+                (_a = api.title) !== null && _a !== void 0 ? _a : "(no title)",
+              content: text,
+              summary: summary,
+              topics: topics,
+              source:
+                (_c =
+                  (_b = api.source) === null || _b === void 0
+                    ? void 0
+                    : _b.name) !== null && _c !== void 0
+                  ? _c
+                  : "newsapi",
+            }),
+          ];
+        case 4:
+          _d.sent();
+          return [3 /*break*/, 7];
+        case 5:
+          err_1 = _d.sent();
+          logger_1.default.error(
+            "Error processing API article ".concat(api.url, ":"),
+            err_1,
+          );
+          return [3 /*break*/, 7];
+        case 6:
+          doneProcessing(api.url);
+          return [7 /*endfinally*/];
+        case 7:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+/* ─────────────────── PAGE‑FETCH ARTICLES ─────────────────── */
+/**
+ * Process a URL to fetch and summarize its content.
+ *
+ * @param url - The URL to process.
+ */
+function processUrl(url) {
+  return __awaiter(this, void 0, void 0, function () {
+    var art, e_1, summary, topics, err_2;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          if (
+            STATIC_EXT_RE.test(url) ||
+            url.includes("#") ||
+            !startProcessing(url)
+          )
+            return [2 /*return*/];
+          _a.label = 1;
+        case 1:
+          _a.trys.push([1, 11, 12, 13]);
+          art = void 0;
+          _a.label = 2;
+        case 2:
+          _a.trys.push([2, 4, , 6]);
+          return [
+            4 /*yield*/,
+            Promise.race([
+              (0, crawler_service_1.fetchStaticArticle)(url),
+              new Promise(function (_, r) {
+                return setTimeout(function () {
+                  return r(new Error("static timeout"));
+                }, MAX_FETCH_TIME_MS);
+              }),
+            ]),
+          ];
+        case 3:
+          art = _a.sent();
+          return [3 /*break*/, 6];
+        case 4:
+          e_1 = _a.sent();
+          logger_1.default.warn(
+            "static FAIL ".concat(url, ": ").concat(e_1, ". Trying dynamic."),
+          );
+          return [4 /*yield*/, (0, crawler_service_1.fetchDynamicArticle)(url)];
+        case 5:
+          art = _a.sent();
+          return [3 /*break*/, 6];
+        case 6:
+          if (!art.content.trim()) {
+            logger_1.default.warn("No content ".concat(url));
+            return [2 /*return*/];
+          }
+          return [
+            4 /*yield*/,
+            (0, summarization_service_1.summarizeContent)(art.content),
+          ];
+        case 7:
+          summary = _a.sent();
+          return [
+            4 /*yield*/,
+            (0, topicExtractor_service_1.extractTopics)(summary),
+          ];
+        case 8:
+          topics = _a.sent();
+          // 3) Upsert
+          return [
+            4 /*yield*/,
+            upsertArticle({
+              url: art.url,
+              title: art.title,
+              content: art.content,
+              summary: summary,
+              topics: topics,
+              source: art.source,
+            }),
+          ];
+        case 9:
+          // 3) Upsert
+          _a.sent();
+          return [4 /*yield*/, wait(DELAY_BETWEEN_REQUESTS_MS)];
+        case 10:
+          _a.sent();
+          return [3 /*break*/, 13];
+        case 11:
+          err_2 = _a.sent();
+          logger_1.default.error(
+            "Full\u2011article pipeline failed ".concat(url, ":"),
+            err_2,
+          );
+          return [3 /*break*/, 13];
+        case 12:
+          doneProcessing(url);
+          return [7 /*endfinally*/];
+        case 13:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+/* ─────────────────── MAIN ─────────────────── */
+/**
+ * Fetch and summarize articles from various sources.
+ */
+function fetchAndSummarize() {
+  return __awaiter(this, void 0, void 0, function () {
+    var crawlJobs,
+      i,
+      crawledRaw,
+      crawled,
+      apiArticles,
+      err_3,
+      allUrls,
+      already,
+      alreadySet,
+      toFetch,
+      i,
+      slice;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          return [4 /*yield*/, mongoose_1.default.connect(MONGODB_URI)];
+        case 1:
+          _a.sent();
+          logger_1.default.info("✅ Mongo connected");
+          /* 1. Crawl homepages */
+          logger_1.default.info("🔍 Crawling homepages…");
+          crawlJobs = [];
+          for (i = 0; i < HOMEPAGE_URLS.length; i += CRAWL_CONCURRENCY) {
+            crawlJobs.push.apply(
+              crawlJobs,
+              HOMEPAGE_URLS.slice(i, i + CRAWL_CONCURRENCY).map(function (u) {
+                return (0, crawler_service_1.crawlArticlesFromHomepage)(
+                  u,
+                  CRAWL_MAX_LINKS,
+                  CRAWL_MAX_DEPTH,
+                );
+              }),
+            );
+          }
+          return [4 /*yield*/, Promise.all(crawlJobs)];
+        case 2:
+          crawledRaw = _a.sent().flat();
+          crawled = crawledRaw.filter(function (u) {
+            return !STATIC_EXT_RE.test(u) && !u.includes("#");
+          });
+          logger_1.default.info(
+            "\uD83D\uDD17 Crawled ".concat(crawled.length, " links"),
+          );
+          /* 2. NewsAPI */
+          logger_1.default.info("📰 Pulling NewsAPI…");
+          apiArticles = [];
+          _a.label = 3;
+        case 3:
+          _a.trys.push([3, 5, , 6]);
+          return [
+            4 /*yield*/,
+            (0, apiFetcher_service_1.fetchArticlesFromNewsAPI)(),
+          ];
+        case 4:
+          apiArticles = _a.sent();
+          return [3 /*break*/, 6];
+        case 5:
+          err_3 = _a.sent();
+          logger_1.default.error("NewsAPI error:", err_3);
+          return [3 /*break*/, 6];
+        case 6:
+          /* 3. Process API articles */
+          return [
+            4 /*yield*/,
+            Promise.allSettled(apiArticles.map(processApiArticle)),
+          ];
+        case 7:
+          /* 3. Process API articles */
+          _a.sent();
+          allUrls = Array.from(
+            new Set(
+              __spreadArray(
+                __spreadArray([], crawled, true),
+                apiArticles.map(function (a) {
+                  return a.url;
+                }),
+                true,
+              ),
+            ),
+          );
+          return [
+            4 /*yield*/,
+            article_model_1.default
+              .find({ url: { $in: allUrls } }, "url")
+              .lean(),
+          ];
+        case 8:
+          already = _a.sent();
+          alreadySet = new Set(
+            already.map(function (d) {
+              return d.url;
+            }),
+          );
+          toFetch = allUrls.filter(function (u) {
+            return !alreadySet.has(u);
+          });
+          logger_1.default.info(
+            "\uD83C\uDD95 ".concat(
+              toFetch.length,
+              " fresh URLs to page\u2011fetch",
+            ),
+          );
+          i = 0;
+          _a.label = 9;
+        case 9:
+          if (!(i < toFetch.length)) return [3 /*break*/, 12];
+          slice = toFetch.slice(i, i + FETCH_CONCURRENCY);
+          return [4 /*yield*/, Promise.allSettled(slice.map(processUrl))];
+        case 10:
+          _a.sent();
+          _a.label = 11;
+        case 11:
+          i += FETCH_CONCURRENCY;
+          return [3 /*break*/, 9];
+        case 12:
+          if (!processingUrls.size) return [3 /*break*/, 14];
+          logger_1.default.debug(
+            "\u23F3 waiting for ".concat(
+              processingUrls.size,
+              " in\u2011flight jobs\u2026",
+            ),
+          );
+          return [4 /*yield*/, wait(1000)];
+        case 13:
+          _a.sent();
+          return [3 /*break*/, 12];
+        case 14:
+          /* 7. Cleanup */
+          logger_1.default.info("🧹 Cleaning up...");
+          return [4 /*yield*/, (0, cleanData_1.cleanupArticles)()];
+        case 15:
+          _a.sent();
+          logger_1.default.info("🏁 Pipeline complete");
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+exports.fetchAndSummarize = fetchAndSummarize;
+// Run the script if executed directly
+if (require.main === module) {
+  fetchAndSummarize()
+    .then(function () {
+      logger_1.default.info("🎉 fetchAndSummarize finished");
+      process.exit(0);
+    })
+    .catch(function (err) {
+      logger_1.default.error("💥 fetchAndSummarize crashed:", err);
+      process.exit(1);
+    });
+}

--- a/crawler/scripts/cleanData.js
+++ b/crawler/scripts/cleanData.js
@@ -1,0 +1,734 @@
+#!/usr/bin/env ts-node
+"use strict";
+/* eslint-disable no-console */
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+var __asyncValues =
+  (this && this.__asyncValues) ||
+  function (o) {
+    if (!Symbol.asyncIterator)
+      throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator],
+      i;
+    return m
+      ? m.call(o)
+      : ((o =
+          typeof __values === "function" ? __values(o) : o[Symbol.iterator]()),
+        (i = {}),
+        verb("next"),
+        verb("throw"),
+        verb("return"),
+        (i[Symbol.asyncIterator] = function () {
+          return this;
+        }),
+        i);
+    function verb(n) {
+      i[n] =
+        o[n] &&
+        function (v) {
+          return new Promise(function (resolve, reject) {
+            (v = o[n](v)), settle(resolve, reject, v.done, v.value);
+          });
+        };
+    }
+    function settle(resolve, reject, d, v) {
+      Promise.resolve(v).then(function (v) {
+        resolve({ value: v, done: d });
+      }, reject);
+    }
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cleanupArticles = void 0;
+var dotenv = require("dotenv");
+dotenv.config();
+var mongoose_1 = require("mongoose");
+/* ─────────── Mongo model (minimal shape) ─────────── */
+var ArticleSchema = new mongoose_1.Schema({
+  url: String,
+  title: String,
+  content: String,
+  summary: String,
+  topics: [String],
+  source: String,
+  fetchedAt: Date,
+});
+// Avoids OverwriteModelError by reusing existing model if already defined
+var Article =
+  mongoose_1.default.models.Article ||
+  mongoose_1.default.model("Article", ArticleSchema);
+/* ─────────── ENV ─────────── */
+var _a = process.env.MONGODB_URI,
+  MONGODB_URI = _a === void 0 ? "" : _a;
+if (!MONGODB_URI) {
+  throw new Error("MONGODB_URI environment variable is required");
+}
+/* ─────────── Heuristic patterns ─────────── */
+/** 1) Non-article URLs (assets, share intents) */
+var STATIC_EXT_RE =
+  /\.(css|js|png|jpe?g|gif|svg|ico|webp|woff2?|ttf|eot|otf|json|xml|webmanifest|pdf|zip|gz|mp4|mpeg|mov)(\?|$)/i;
+var SHARE_URL_RE =
+  /(twitter\.com\/intent|x\.com\/intent|facebook\.com\/sharer|linkedin\.com\/share|pinterest\.com\/pin\/create)/i;
+/** 2) Pages that are clearly errors or placeholders */
+var ERROR_TITLE_RE =
+  /\b(page\s+(?:not\s+found|unavailable)|404\s+error|error\s+404|oops!|access\s+denied|forbidden|blocked)\b/i;
+var ERROR_CONTENT_RE =
+  /(STATUS CODE:\s*404|does not exist|currently unavailable|404\s*error|page not found|access denied|forbidden|internal server error|http 403|http 404|http 500)/i;
+/** 3) Boilerplate apology / inability text */
+var BOILERPLATE_RE =
+  /\b(I am sorry|unable to (?:access|summarize|process|retrieve))\b/i;
+/** 4) Too-short content threshold */
+var SHORT_CONTENT_LEN = 200;
+/** 5) Detect binary/control characters in the first 100 chars */
+function looksBinary(txt) {
+  if (txt === void 0) {
+    txt = "";
+  }
+  return /[\u0000-\u001F]/.test(txt.slice(0, 100));
+}
+/**
+ * Connects to Mongo (if needed), deletes unmeaningful articles by a series
+ * of heuristics, then normalizes odd titles, cleans repeated or garbled
+ * suffixes, strips camel-case concatenated suffixes, then disconnects (only
+ * if it opened the connection). Logs each phase’s result.
+ */
+function cleanupArticles() {
+  var _a,
+    e_1,
+    _b,
+    _c,
+    _d,
+    e_2,
+    _e,
+    _f,
+    _g,
+    e_3,
+    _h,
+    _j,
+    _k,
+    e_4,
+    _l,
+    _m,
+    _o,
+    e_5,
+    _p,
+    _q;
+  return __awaiter(this, void 0, void 0, function () {
+    var alreadyConnected,
+      urlDeleted,
+      toDelete,
+      cursor,
+      _r,
+      cursor_1,
+      cursor_1_1,
+      doc,
+      title,
+      content,
+      summary,
+      isUntitled,
+      tooShort,
+      isBinary,
+      isErrorish,
+      isBoiler,
+      e_1_1,
+      heurDeleted,
+      _s,
+      repeaterBulk,
+      cursor3,
+      _t,
+      cursor3_1,
+      cursor3_1_1,
+      doc,
+      orig,
+      dupMatch,
+      cleaned,
+      e_2_1,
+      res,
+      camelBulk,
+      cursor4,
+      _loop_1,
+      _u,
+      cursor4_1,
+      cursor4_1_1,
+      e_3_1,
+      res,
+      suffixBulk,
+      cursor5,
+      TRAILING_UPPER_RE,
+      _v,
+      cursor5_1,
+      cursor5_1_1,
+      doc,
+      orig,
+      cleaned,
+      e_4_1,
+      res,
+      ODD_TITLE_RE,
+      bulkOps,
+      cursor6,
+      _w,
+      cursor6_1,
+      cursor6_1_1,
+      doc,
+      rawTitle,
+      cleaned,
+      e_5_1,
+      res;
+    return __generator(this, function (_x) {
+      switch (_x.label) {
+        case 0:
+          alreadyConnected = mongoose_1.default.connection.readyState === 1;
+          if (!!alreadyConnected) return [3 /*break*/, 2];
+          return [4 /*yield*/, mongoose_1.default.connect(MONGODB_URI)];
+        case 1:
+          _x.sent();
+          console.log("✅ MongoDB connected");
+          return [3 /*break*/, 3];
+        case 2:
+          console.log("🔄 Reusing existing MongoDB connection");
+          _x.label = 3;
+        case 3:
+          return [
+            4 /*yield*/,
+            Article.deleteMany({
+              $or: [
+                { url: { $regex: STATIC_EXT_RE } },
+                { url: { $regex: SHARE_URL_RE } },
+              ],
+            }),
+          ];
+        case 4:
+          urlDeleted = _x.sent().deletedCount;
+          console.log(
+            "Phase 1 \u2014 removed by URL patterns: ".concat(urlDeleted),
+          );
+          toDelete = [];
+          cursor = Article.find(
+            {},
+            { _id: 1, title: 1, content: 1, summary: 1 },
+          )
+            .lean()
+            .cursor();
+          _x.label = 5;
+        case 5:
+          _x.trys.push([5, 10, 11, 16]);
+          (_r = true), (cursor_1 = __asyncValues(cursor));
+          _x.label = 6;
+        case 6:
+          return [4 /*yield*/, cursor_1.next()];
+        case 7:
+          if (!((cursor_1_1 = _x.sent()), (_a = cursor_1_1.done), !_a))
+            return [3 /*break*/, 9];
+          _c = cursor_1_1.value;
+          _r = false;
+          try {
+            doc = _c;
+            title = (doc.title || "").trim();
+            content = (doc.content || "").trim();
+            summary = (doc.summary || "").trim();
+            // Remove any articles containing embedded iframes or similar tags
+            if (/<iframe\b/i.test(content)) {
+              toDelete.push(doc._id);
+              return [3 /*break*/, 8];
+            }
+            isUntitled = title.toLowerCase() === "untitled";
+            tooShort = !title && content.length < SHORT_CONTENT_LEN;
+            isBinary = looksBinary(content);
+            isErrorish =
+              ERROR_TITLE_RE.test(title) || ERROR_CONTENT_RE.test(content);
+            isBoiler =
+              BOILERPLATE_RE.test(content) || BOILERPLATE_RE.test(summary);
+            if (isUntitled || tooShort || isBinary || isErrorish || isBoiler) {
+              toDelete.push(doc._id);
+            }
+          } finally {
+            _r = true;
+          }
+          _x.label = 8;
+        case 8:
+          return [3 /*break*/, 6];
+        case 9:
+          return [3 /*break*/, 16];
+        case 10:
+          e_1_1 = _x.sent();
+          e_1 = { error: e_1_1 };
+          return [3 /*break*/, 16];
+        case 11:
+          _x.trys.push([11, , 14, 15]);
+          if (!(!_r && !_a && (_b = cursor_1.return))) return [3 /*break*/, 13];
+          return [4 /*yield*/, _b.call(cursor_1)];
+        case 12:
+          _x.sent();
+          _x.label = 13;
+        case 13:
+          return [3 /*break*/, 15];
+        case 14:
+          if (e_1) throw e_1.error;
+          return [7 /*endfinally*/];
+        case 15:
+          return [7 /*endfinally*/];
+        case 16:
+          if (!toDelete.length) return [3 /*break*/, 18];
+          return [4 /*yield*/, Article.deleteMany({ _id: { $in: toDelete } })];
+        case 17:
+          _s = _x.sent();
+          return [3 /*break*/, 19];
+        case 18:
+          _s = { deletedCount: 0 };
+          _x.label = 19;
+        case 19:
+          heurDeleted = _s.deletedCount;
+          console.log(
+            "Phase 2 \u2014 removed by content/title heuristics & embeds: ".concat(
+              heurDeleted,
+            ),
+          );
+          repeaterBulk = [];
+          cursor3 = Article.find({}, { _id: 1, title: 1 }).lean().cursor();
+          _x.label = 20;
+        case 20:
+          _x.trys.push([20, 25, 26, 31]);
+          (_t = true), (cursor3_1 = __asyncValues(cursor3));
+          _x.label = 21;
+        case 21:
+          return [4 /*yield*/, cursor3_1.next()];
+        case 22:
+          if (!((cursor3_1_1 = _x.sent()), (_d = cursor3_1_1.done), !_d))
+            return [3 /*break*/, 24];
+          _f = cursor3_1_1.value;
+          _t = false;
+          try {
+            doc = _f;
+            orig = (doc.title || "").trim();
+            dupMatch = orig.match(/^(.*?)([A-Za-z]{2,})\2$/);
+            if (dupMatch) {
+              cleaned = (dupMatch[1] + dupMatch[2]).trim();
+              if (cleaned !== orig) {
+                repeaterBulk.push({
+                  updateOne: {
+                    filter: { _id: doc._id },
+                    update: { $set: { title: cleaned } },
+                  },
+                });
+              }
+            }
+          } finally {
+            _t = true;
+          }
+          _x.label = 23;
+        case 23:
+          return [3 /*break*/, 21];
+        case 24:
+          return [3 /*break*/, 31];
+        case 25:
+          e_2_1 = _x.sent();
+          e_2 = { error: e_2_1 };
+          return [3 /*break*/, 31];
+        case 26:
+          _x.trys.push([26, , 29, 30]);
+          if (!(!_t && !_d && (_e = cursor3_1.return)))
+            return [3 /*break*/, 28];
+          return [4 /*yield*/, _e.call(cursor3_1)];
+        case 27:
+          _x.sent();
+          _x.label = 28;
+        case 28:
+          return [3 /*break*/, 30];
+        case 29:
+          if (e_2) throw e_2.error;
+          return [7 /*endfinally*/];
+        case 30:
+          return [7 /*endfinally*/];
+        case 31:
+          if (!repeaterBulk.length) return [3 /*break*/, 33];
+          return [4 /*yield*/, Article.bulkWrite(repeaterBulk)];
+        case 32:
+          res = _x.sent();
+          console.log(
+            "Phase 3 \u2014 cleaned repeated title segments on ".concat(
+              res.modifiedCount,
+              " articles",
+            ),
+          );
+          return [3 /*break*/, 34];
+        case 33:
+          console.log("Phase 3 — no repeated title segments found to clean");
+          _x.label = 34;
+        case 34:
+          camelBulk = [];
+          cursor4 = Article.find({}, { _id: 1, title: 1 }).lean().cursor();
+          _x.label = 35;
+        case 35:
+          _x.trys.push([35, 40, 41, 46]);
+          _loop_1 = function () {
+            _j = cursor4_1_1.value;
+            _u = false;
+            try {
+              var doc = _j;
+              var orig = (doc.title || "").trim();
+              var idx = orig.split("").findIndex(function (ch, i) {
+                return i > 0 && /[a-z]/.test(orig[i - 1]) && /[A-Z]/.test(ch);
+              });
+              if (idx > 0) {
+                var cleaned = orig.slice(0, idx).trim();
+                if (cleaned && cleaned !== orig) {
+                  camelBulk.push({
+                    updateOne: {
+                      filter: { _id: doc._id },
+                      update: { $set: { title: cleaned } },
+                    },
+                  });
+                }
+              }
+            } finally {
+              _u = true;
+            }
+          };
+          (_u = true), (cursor4_1 = __asyncValues(cursor4));
+          _x.label = 36;
+        case 36:
+          return [4 /*yield*/, cursor4_1.next()];
+        case 37:
+          if (!((cursor4_1_1 = _x.sent()), (_g = cursor4_1_1.done), !_g))
+            return [3 /*break*/, 39];
+          _loop_1();
+          _x.label = 38;
+        case 38:
+          return [3 /*break*/, 36];
+        case 39:
+          return [3 /*break*/, 46];
+        case 40:
+          e_3_1 = _x.sent();
+          e_3 = { error: e_3_1 };
+          return [3 /*break*/, 46];
+        case 41:
+          _x.trys.push([41, , 44, 45]);
+          if (!(!_u && !_g && (_h = cursor4_1.return)))
+            return [3 /*break*/, 43];
+          return [4 /*yield*/, _h.call(cursor4_1)];
+        case 42:
+          _x.sent();
+          _x.label = 43;
+        case 43:
+          return [3 /*break*/, 45];
+        case 44:
+          if (e_3) throw e_3.error;
+          return [7 /*endfinally*/];
+        case 45:
+          return [7 /*endfinally*/];
+        case 46:
+          if (!camelBulk.length) return [3 /*break*/, 48];
+          return [4 /*yield*/, Article.bulkWrite(camelBulk)];
+        case 47:
+          res = _x.sent();
+          console.log(
+            "Phase 4 \u2014 stripped camel-case suffixes on ".concat(
+              res.modifiedCount,
+              " articles",
+            ),
+          );
+          return [3 /*break*/, 49];
+        case 48:
+          console.log("Phase 4 — no camel-case suffixes found to strip");
+          _x.label = 49;
+        case 49:
+          suffixBulk = [];
+          cursor5 = Article.find({}, { _id: 1, title: 1 }).lean().cursor();
+          TRAILING_UPPER_RE = /[A-Z]{3,}$/;
+          _x.label = 50;
+        case 50:
+          _x.trys.push([50, 55, 56, 61]);
+          (_v = true), (cursor5_1 = __asyncValues(cursor5));
+          _x.label = 51;
+        case 51:
+          return [4 /*yield*/, cursor5_1.next()];
+        case 52:
+          if (!((cursor5_1_1 = _x.sent()), (_k = cursor5_1_1.done), !_k))
+            return [3 /*break*/, 54];
+          _m = cursor5_1_1.value;
+          _v = false;
+          try {
+            doc = _m;
+            orig = (doc.title || "").trim();
+            if (TRAILING_UPPER_RE.test(orig)) {
+              cleaned = orig.replace(TRAILING_UPPER_RE, "").trim();
+              if (cleaned && cleaned !== orig) {
+                suffixBulk.push({
+                  updateOne: {
+                    filter: { _id: doc._id },
+                    update: { $set: { title: cleaned } },
+                  },
+                });
+              }
+            }
+          } finally {
+            _v = true;
+          }
+          _x.label = 53;
+        case 53:
+          return [3 /*break*/, 51];
+        case 54:
+          return [3 /*break*/, 61];
+        case 55:
+          e_4_1 = _x.sent();
+          e_4 = { error: e_4_1 };
+          return [3 /*break*/, 61];
+        case 56:
+          _x.trys.push([56, , 59, 60]);
+          if (!(!_v && !_k && (_l = cursor5_1.return)))
+            return [3 /*break*/, 58];
+          return [4 /*yield*/, _l.call(cursor5_1)];
+        case 57:
+          _x.sent();
+          _x.label = 58;
+        case 58:
+          return [3 /*break*/, 60];
+        case 59:
+          if (e_4) throw e_4.error;
+          return [7 /*endfinally*/];
+        case 60:
+          return [7 /*endfinally*/];
+        case 61:
+          if (!suffixBulk.length) return [3 /*break*/, 63];
+          return [4 /*yield*/, Article.bulkWrite(suffixBulk)];
+        case 62:
+          res = _x.sent();
+          console.log(
+            "Phase 5 \u2014 stripped garbled suffixes on ".concat(
+              res.modifiedCount,
+              " articles",
+            ),
+          );
+          return [3 /*break*/, 64];
+        case 63:
+          console.log("Phase 5 — no garbled suffixes found to strip");
+          _x.label = 64;
+        case 64:
+          ODD_TITLE_RE = /^[^A-Za-z0-9]+/;
+          bulkOps = [];
+          cursor6 = Article.find(
+            { title: { $regex: ODD_TITLE_RE } },
+            { _id: 1, title: 1 },
+          )
+            .lean()
+            .cursor();
+          _x.label = 65;
+        case 65:
+          _x.trys.push([65, 70, 71, 76]);
+          (_w = true), (cursor6_1 = __asyncValues(cursor6));
+          _x.label = 66;
+        case 66:
+          return [4 /*yield*/, cursor6_1.next()];
+        case 67:
+          if (!((cursor6_1_1 = _x.sent()), (_o = cursor6_1_1.done), !_o))
+            return [3 /*break*/, 69];
+          _q = cursor6_1_1.value;
+          _w = false;
+          try {
+            doc = _q;
+            rawTitle = doc.title || "";
+            cleaned = rawTitle.replace(ODD_TITLE_RE, "").trim();
+            if (cleaned !== rawTitle) {
+              bulkOps.push({
+                updateOne: {
+                  filter: { _id: doc._id },
+                  update: { $set: { title: cleaned } },
+                },
+              });
+            }
+          } finally {
+            _w = true;
+          }
+          _x.label = 68;
+        case 68:
+          return [3 /*break*/, 66];
+        case 69:
+          return [3 /*break*/, 76];
+        case 70:
+          e_5_1 = _x.sent();
+          e_5 = { error: e_5_1 };
+          return [3 /*break*/, 76];
+        case 71:
+          _x.trys.push([71, , 74, 75]);
+          if (!(!_w && !_o && (_p = cursor6_1.return)))
+            return [3 /*break*/, 73];
+          return [4 /*yield*/, _p.call(cursor6_1)];
+        case 72:
+          _x.sent();
+          _x.label = 73;
+        case 73:
+          return [3 /*break*/, 75];
+        case 74:
+          if (e_5) throw e_5.error;
+          return [7 /*endfinally*/];
+        case 75:
+          return [7 /*endfinally*/];
+        case 76:
+          if (!bulkOps.length) return [3 /*break*/, 78];
+          return [4 /*yield*/, Article.bulkWrite(bulkOps)];
+        case 77:
+          res = _x.sent();
+          console.log(
+            "Phase 6 \u2014 normalized titles on ".concat(
+              res.modifiedCount,
+              " articles",
+            ),
+          );
+          return [3 /*break*/, 79];
+        case 78:
+          console.log("Phase 6 — no odd titles found to normalize");
+          _x.label = 79;
+        case 79:
+          console.log("🧹 Cleanup complete");
+          if (!!alreadyConnected) return [3 /*break*/, 81];
+          return [4 /*yield*/, mongoose_1.default.disconnect()];
+        case 80:
+          _x.sent();
+          console.log("✅ MongoDB disconnected");
+          _x.label = 81;
+        case 81:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+exports.cleanupArticles = cleanupArticles;
+/**
+ * If invoked directly (`ts-node cleanup-articles.ts`), run immediately.
+ */
+if (require.main === module) {
+  cleanupArticles().catch(function (err) {
+    console.error("Cleanup failed:", err);
+    process.exit(1);
+  });
+}

--- a/crawler/services/apiFetcher.service.js
+++ b/crawler/services/apiFetcher.service.js
@@ -1,0 +1,337 @@
+"use strict";
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+var __spreadArray =
+  (this && this.__spreadArray) ||
+  function (to, from, pack) {
+    if (pack || arguments.length === 2)
+      for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+          if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+          ar[i] = from[i];
+        }
+      }
+    return to.concat(ar || Array.prototype.slice.call(from));
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchArticlesFromNewsAPI = void 0;
+var axios_1 = require("axios");
+var dotenv = require("dotenv");
+var PAGE_SIZE = 100;
+var STATIC_EXT_RE =
+  /\.(css|js|png|jpe?g|gif|svg|ico|webp|woff2?|eot|ttf|otf|json|webmanifest|xml|rss|atom|mp4|mpeg|mov|zip|gz|pdf)(\?|$)/i;
+dotenv.config();
+/* ─────────── helper to rotate keys ─────────── */
+var NEWS_KEYS = [
+  process.env.NEWS_API_KEY,
+  process.env.NEWS_API_KEY1,
+  process.env.NEWS_API_KEY2,
+  process.env.NEWS_API_KEY3,
+  process.env.NEWS_API_KEY4,
+  process.env.NEWS_API_KEY5,
+  process.env.NEWS_API_KEY6,
+  process.env.NEWS_API_KEY7,
+].filter(Boolean);
+if (!NEWS_KEYS.length) throw new Error("No NEWS_API_KEY* provided");
+var keyIdx = 0;
+/**
+ * Rotate to the next NewsAPI key.
+ */
+var nextKey = function () {
+  keyIdx = (keyIdx + 1) % NEWS_KEYS.length;
+  return NEWS_KEYS[keyIdx];
+};
+/**
+ * Get the articles from the NewsAPI with key rotation.
+ *
+ * @param urlBase - The base URL for the API request.
+ */
+function safeGet(urlBase) {
+  var _a;
+  return __awaiter(this, void 0, void 0, function () {
+    var tries, url, err_1, ax, status_1;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          tries = 0;
+          _b.label = 1;
+        case 1:
+          if (!(tries < NEWS_KEYS.length)) return [3 /*break*/, 6];
+          url = "".concat(urlBase, "&apiKey=").concat(NEWS_KEYS[keyIdx]);
+          _b.label = 2;
+        case 2:
+          _b.trys.push([2, 4, , 5]);
+          return [4 /*yield*/, axios_1.default.get(url)];
+        case 3:
+          return [2 /*return*/, _b.sent()];
+        case 4:
+          err_1 = _b.sent();
+          ax = err_1;
+          status_1 =
+            ((_a = ax.response) === null || _a === void 0
+              ? void 0
+              : _a.status) || 0;
+          if (status_1 === 401 || status_1 === 429) {
+            console.warn(
+              "\uD83D\uDD11 rotate NewsAPI key \u2192 ".concat(
+                (keyIdx + 1) % NEWS_KEYS.length,
+              ),
+            );
+            nextKey();
+            tries++;
+            return [3 /*break*/, 1];
+          }
+          throw err_1;
+        case 5:
+          return [3 /*break*/, 1];
+        case 6:
+          throw new Error("All NewsAPI keys exhausted");
+      }
+    });
+  });
+}
+/**
+ * Fetch articles from the NewsAPI.
+ *
+ * @returns An array of articles.
+ */
+var fetchArticlesFromNewsAPI = function () {
+  return __awaiter(void 0, void 0, void 0, function () {
+    var domains,
+      query,
+      base,
+      firstResp,
+      total,
+      totalPages,
+      first,
+      pages,
+      p,
+      chunks,
+      CONC,
+      i,
+      batch,
+      resps;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          domains =
+            "nytimes.com,washingtonpost.com,dallasnews.com,statesman.com,houstonchronicle.com,expressnews.com";
+          query = encodeURIComponent("politics OR government OR election");
+          base =
+            "https://newsapi.org/v2/everything?language=en&q=".concat(query) +
+            "&sortBy=publishedAt&domains="
+              .concat(domains, "&pageSize=")
+              .concat(PAGE_SIZE);
+          return [4 /*yield*/, safeGet("".concat(base, "&page=1"))];
+        case 1:
+          firstResp = _a.sent();
+          total = firstResp.data.totalResults || 0;
+          totalPages = Math.ceil(total / PAGE_SIZE);
+          first = firstResp.data.articles
+            .filter(function (a) {
+              return !STATIC_EXT_RE.test(a.url) && !a.url.includes("#");
+            })
+            .map(function (a) {
+              return {
+                url: a.url,
+                title: a.title,
+                content: a.content || a.description || "",
+                source: a.source.name || "NewsAPI",
+              };
+            });
+          pages = [];
+          for (p = 2; p <= totalPages; p++) pages.push(p);
+          chunks = [];
+          CONC = 5;
+          i = 0;
+          _a.label = 2;
+        case 2:
+          if (!(i < pages.length)) return [3 /*break*/, 5];
+          batch = pages.slice(i, i + CONC);
+          return [
+            4 /*yield*/,
+            Promise.all(
+              batch.map(function (page) {
+                return __awaiter(void 0, void 0, void 0, function () {
+                  var resp;
+                  return __generator(this, function (_a) {
+                    switch (_a.label) {
+                      case 0:
+                        return [
+                          4 /*yield*/,
+                          safeGet("".concat(base, "&page=").concat(page)),
+                        ];
+                      case 1:
+                        resp = _a.sent();
+                        return [
+                          2 /*return*/,
+                          resp.data.articles
+                            .filter(function (x) {
+                              return (
+                                !STATIC_EXT_RE.test(x.url) &&
+                                !x.url.includes("#")
+                              );
+                            })
+                            .map(function (x) {
+                              return {
+                                url: x.url,
+                                title: x.title,
+                                content: x.content || x.description || "",
+                                source: x.source.name || "NewsAPI",
+                              };
+                            }),
+                        ];
+                    }
+                  });
+                });
+              }),
+            ),
+          ];
+        case 3:
+          resps = _a.sent();
+          chunks.push.apply(chunks, resps);
+          _a.label = 4;
+        case 4:
+          i += CONC;
+          return [3 /*break*/, 2];
+        case 5:
+          return [
+            2 /*return*/,
+            __spreadArray(__spreadArray([], first, true), chunks.flat(), true),
+          ];
+      }
+    });
+  });
+};
+exports.fetchArticlesFromNewsAPI = fetchArticlesFromNewsAPI;

--- a/crawler/services/crawler.service.js
+++ b/crawler/services/crawler.service.js
@@ -1,0 +1,529 @@
+"use strict";
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.crawlArticlesFromHomepage =
+  exports.fetchStaticArticle =
+  exports.fetchDynamicArticle =
+    void 0;
+var puppeteer_core_1 = require("puppeteer-core");
+var chromium = require("@sparticuz/chromium");
+var axios_1 = require("axios");
+var cheerio = require("cheerio");
+var url_1 = require("url");
+var RETRY_DELAY_MS = 2000;
+var AXIOS_TIMEOUT_MS = 10000; // Abort axios requests after 10 seconds
+/**
+ * Delay function to pause execution for a specified number of milliseconds.
+ *
+ * @param ms - The number of milliseconds to wait.
+ */
+var delay = function (ms) {
+  return new Promise(function (resolve) {
+    return setTimeout(resolve, ms);
+  });
+};
+/**
+ * Derive a title from the raw title or the body of the article.
+ *
+ * @param rawTitle - The raw title of the article.
+ * @param content - The body content of the article.
+ */
+var deriveTitle = function (rawTitle, content) {
+  var title = rawTitle.trim();
+  if (title) return title;
+  var firstSentenceMatch = content.match(/(.{1,120}?[.!?])\s/);
+  if (firstSentenceMatch) return firstSentenceMatch[1].trim();
+  var firstWords = content.split(/\s+/).slice(0, 10).join(" ").trim();
+  return firstWords || "Untitled";
+};
+/**
+ * Fetch a dynamic article using Puppeteer.
+ *
+ * @param url - The URL of the article to fetch.
+ */
+var fetchDynamicArticle = function (url) {
+  return __awaiter(void 0, void 0, void 0, function () {
+    var executablePath, browser, page, _a, err_1, html, $, content, title;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          return [4 /*yield*/, chromium.executablePath()];
+        case 1:
+          executablePath = _b.sent();
+          return [
+            4 /*yield*/,
+            puppeteer_core_1.default.launch({
+              executablePath: executablePath,
+              headless: chromium.headless,
+              args: chromium.args,
+            }),
+          ];
+        case 2:
+          browser = _b.sent();
+          return [4 /*yield*/, browser.newPage()];
+        case 3:
+          page = _b.sent();
+          return [
+            4 /*yield*/,
+            page.setUserAgent(
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+            ),
+          ];
+        case 4:
+          _b.sent();
+          _b.label = 5;
+        case 5:
+          _b.trys.push([5, 7, , 13]);
+          return [
+            4 /*yield*/,
+            page.goto(url, { waitUntil: "networkidle2", timeout: 15000 }),
+          ];
+        case 6:
+          _b.sent();
+          return [3 /*break*/, 13];
+        case 7:
+          _a = _b.sent();
+          console.warn(
+            "networkidle2 timed out for ".concat(
+              url,
+              ", falling back to domcontentloaded...",
+            ),
+          );
+          _b.label = 8;
+        case 8:
+          _b.trys.push([8, 10, , 12]);
+          return [
+            4 /*yield*/,
+            page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 }),
+          ];
+        case 9:
+          _b.sent();
+          return [3 /*break*/, 12];
+        case 10:
+          err_1 = _b.sent();
+          return [4 /*yield*/, browser.close()];
+        case 11:
+          _b.sent();
+          throw err_1;
+        case 12:
+          return [3 /*break*/, 13];
+        case 13:
+          return [4 /*yield*/, page.content()];
+        case 14:
+          html = _b.sent();
+          return [4 /*yield*/, browser.close()];
+        case 15:
+          _b.sent();
+          $ = cheerio.load(html);
+          // Remove unwanted elements before extracting text
+          $("script, style, iframe, noscript").remove();
+          $('head [type="application/ld+json"]').remove();
+          content = $("body").text().replace(/\s+/g, " ").trim() || "";
+          title = deriveTitle($("title").text(), content);
+          return [
+            2 /*return*/,
+            { url: url, title: title, content: content, source: url },
+          ];
+      }
+    });
+  });
+};
+exports.fetchDynamicArticle = fetchDynamicArticle;
+/**
+ * Regular expression to match static file extensions.
+ *
+ * @param url - The URL to check.
+ * @param retries - The number of retries left.
+ */
+var fetchStaticArticle = function (url, retries) {
+  if (retries === void 0) {
+    retries = 3;
+  }
+  return __awaiter(void 0, void 0, void 0, function () {
+    var data, $, content, title, err_2;
+    var _a;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          _b.trys.push([0, 2, , 5]);
+          return [
+            4 /*yield*/,
+            axios_1.default.get(url, {
+              headers: {
+                "User-Agent":
+                  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                  "(KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36",
+                Accept:
+                  "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+              },
+              timeout: AXIOS_TIMEOUT_MS,
+            }),
+          ];
+        case 1:
+          data = _b.sent().data;
+          $ = cheerio.load(data);
+          // Remove unwanted elements before extracting text
+          $("script, style, iframe, noscript").remove();
+          $('head [type="application/ld+json"]').remove();
+          content = $("body").text().replace(/\s+/g, " ").trim() || "";
+          title = deriveTitle($("title").text(), content);
+          return [
+            2 /*return*/,
+            { url: url, title: title, content: content, source: url },
+          ];
+        case 2:
+          err_2 = _b.sent();
+          if (
+            !(
+              retries > 0 &&
+              (err_2.code === "ECONNRESET" || err_2.code === "ECONNABORTED")
+            )
+          )
+            return [3 /*break*/, 4];
+          console.warn(
+            "Error ("
+              .concat(err_2.code, ") fetching ")
+              .concat(url, ", retrying in ")
+              .concat(RETRY_DELAY_MS, "ms..."),
+          );
+          return [4 /*yield*/, delay(RETRY_DELAY_MS)];
+        case 3:
+          _b.sent();
+          return [
+            2 /*return*/,
+            (0, exports.fetchStaticArticle)(url, retries - 1),
+          ];
+        case 4:
+          // On 403, fall back to dynamic
+          if (
+            axios_1.default.isAxiosError(err_2) &&
+            ((_a = err_2.response) === null || _a === void 0
+              ? void 0
+              : _a.status) === 403
+          ) {
+            console.warn(
+              "Static fetch 403 for ".concat(
+                url,
+                ", falling back to dynamic...",
+              ),
+            );
+            return [2 /*return*/, (0, exports.fetchDynamicArticle)(url)];
+          }
+          throw err_2;
+        case 5:
+          return [2 /*return*/];
+      }
+    });
+  });
+};
+exports.fetchStaticArticle = fetchStaticArticle;
+/**
+ * Crawl a list of homepage URLs to find article links.
+ *
+ * @param homepageUrls - The homepage URLs to crawl.
+ * @param maxLinks - The maximum number of links to collect.
+ * @param maxDepth - The maximum depth to crawl.
+ * @param concurrency - The number of concurrent requests.
+ */
+var crawlArticlesFromHomepage = function (
+  homepageUrls,
+  maxLinks,
+  maxDepth,
+  concurrency,
+) {
+  if (maxLinks === void 0) {
+    maxLinks = 20;
+  }
+  if (maxDepth === void 0) {
+    maxDepth = 1;
+  }
+  if (concurrency === void 0) {
+    concurrency = 5;
+  }
+  return __awaiter(void 0, void 0, void 0, function () {
+    var seeds, queue, visited, collected, worker;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          seeds = Array.isArray(homepageUrls) ? homepageUrls : [homepageUrls];
+          queue = seeds.map(function (u) {
+            return {
+              url: u,
+              depth: 0,
+              domain: new url_1.URL(u).hostname,
+            };
+          });
+          visited = new Set();
+          collected = new Set();
+          worker = function () {
+            return __awaiter(void 0, void 0, void 0, function () {
+              var _loop_1, state_1;
+              return __generator(this, function (_a) {
+                switch (_a.label) {
+                  case 0:
+                    _loop_1 = function () {
+                      var item,
+                        url,
+                        depth,
+                        domain,
+                        html,
+                        resp,
+                        _b,
+                        $,
+                        linksOnPage,
+                        _i,
+                        linksOnPage_1,
+                        link,
+                        _c,
+                        linksOnPage_2,
+                        link;
+                      return __generator(this, function (_d) {
+                        switch (_d.label) {
+                          case 0:
+                            item = queue.shift();
+                            if (!item) return [2 /*return*/, "break"];
+                            (url = item.url),
+                              (depth = item.depth),
+                              (domain = item.domain);
+                            if (visited.has(url))
+                              return [2 /*return*/, "continue"];
+                            visited.add(url);
+                            html = void 0;
+                            _d.label = 1;
+                          case 1:
+                            _d.trys.push([1, 3, , 4]);
+                            return [
+                              4 /*yield*/,
+                              axios_1.default.get(url, {
+                                headers: {
+                                  "User-Agent":
+                                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+                                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 " +
+                                    "Safari/537.36",
+                                  Accept:
+                                    "text/html,application/xhtml+xml,application/xml;" +
+                                    "q=0.9,image/webp,*/*;q=0.8",
+                                },
+                                timeout: AXIOS_TIMEOUT_MS,
+                              }),
+                            ];
+                          case 2:
+                            resp = _d.sent();
+                            html = resp.data;
+                            return [3 /*break*/, 4];
+                          case 3:
+                            _b = _d.sent();
+                            return [2 /*return*/, "continue"];
+                          case 4:
+                            $ = cheerio.load(html);
+                            linksOnPage = [];
+                            $("a[href]").each(function (_, el) {
+                              var href = $(el).attr("href");
+                              if (!href) return;
+                              try {
+                                var abs = new url_1.URL(href, url).href;
+                                if (new url_1.URL(abs).hostname === domain) {
+                                  linksOnPage.push(abs);
+                                }
+                              } catch (_a) {
+                                /* ignore malformed URLs */
+                              }
+                            });
+                            // Collect up to maxLinks
+                            for (
+                              _i = 0, linksOnPage_1 = linksOnPage;
+                              _i < linksOnPage_1.length;
+                              _i++
+                            ) {
+                              link = linksOnPage_1[_i];
+                              if (collected.size >= maxLinks) break;
+                              if (!collected.has(link) && link !== url) {
+                                collected.add(link);
+                              }
+                            }
+                            // Enqueue next-depth
+                            if (depth + 1 < maxDepth) {
+                              for (
+                                _c = 0, linksOnPage_2 = linksOnPage;
+                                _c < linksOnPage_2.length;
+                                _c++
+                              ) {
+                                link = linksOnPage_2[_c];
+                                if (!visited.has(link)) {
+                                  queue.push({
+                                    url: link,
+                                    depth: depth + 1,
+                                    domain: domain,
+                                  });
+                                }
+                              }
+                            }
+                            return [2 /*return*/];
+                        }
+                      });
+                    };
+                    _a.label = 1;
+                  case 1:
+                    if (!(collected.size < maxLinks)) return [3 /*break*/, 3];
+                    return [5 /*yield**/, _loop_1()];
+                  case 2:
+                    state_1 = _a.sent();
+                    if (state_1 === "break") return [3 /*break*/, 3];
+                    return [3 /*break*/, 1];
+                  case 3:
+                    return [2 /*return*/];
+                }
+              });
+            });
+          };
+          // Launch workers that naturally dovetail across all seeded homepages
+          return [
+            4 /*yield*/,
+            Promise.all(
+              Array.from({ length: concurrency }, function () {
+                return worker();
+              }),
+            ),
+          ];
+        case 1:
+          // Launch workers that naturally dovetail across all seeded homepages
+          _a.sent();
+          return [2 /*return*/, Array.from(collected).slice(0, maxLinks)];
+      }
+    });
+  });
+};
+exports.crawlArticlesFromHomepage = crawlArticlesFromHomepage;

--- a/crawler/services/summarization.service.js
+++ b/crawler/services/summarization.service.js
@@ -1,0 +1,329 @@
+"use strict";
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.summarizeContent = void 0;
+var generative_ai_1 = require("@google/generative-ai");
+var dotenv = require("dotenv");
+dotenv.config();
+/* ─────────────────  KEY + MODEL ROTATION ───────────────── */
+var API_KEYS = [
+  process.env.GOOGLE_AI_API_KEY,
+  process.env.GOOGLE_AI_API_KEY1,
+  process.env.GOOGLE_AI_API_KEY2,
+  process.env.GOOGLE_AI_API_KEY3,
+].filter(Boolean);
+if (!API_KEYS.length) throw new Error("No GOOGLE_AI_API_KEY* values found");
+var MODELS = ["gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-flash"];
+var MAX_RETRIES_PER_PAIR = 2;
+var BACKOFF_MS = 1500;
+/* ─────────────────  PARAMS ───────────────── */
+var SYSTEM = (
+  (_a = process.env.AI_INSTRUCTIONS) !== null && _a !== void 0 ? _a : ""
+).trim();
+var generationConfig = {
+  temperature: 0.9,
+  topP: 0.95,
+  topK: 64,
+  maxOutputTokens: 8192,
+};
+var safetySettings = [
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_HARASSMENT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+];
+/**
+ * Check if the error is due to rate limiting or quota exceeded.
+ *
+ * @param e - The error object.
+ */
+var isRateOrQuota = function (e) {
+  return (
+    (e === null || e === void 0 ? void 0 : e.status) === 429 ||
+    /quota|rate|exceed/i.test(
+      (e === null || e === void 0 ? void 0 : e.message) || "",
+    )
+  );
+};
+/**
+ * Check if the error is due to overload or service unavailability.
+ *
+ * @param e - The error object.
+ */
+var isOverloaded = function (e) {
+  return (
+    (e === null || e === void 0 ? void 0 : e.status) === 503 ||
+    /overload|unavailable/i.test(
+      (e === null || e === void 0 ? void 0 : e.message) || "",
+    )
+  );
+};
+/* ─────────────────────────────  EXPORT  ───────────────────────────── */
+/**
+ * Summarize the content of an article using Google Generative AI.
+ *
+ * @param article - The article content to summarize.
+ * @returns The summarized text.
+ */
+function summarizeContent(article) {
+  var _a, _b;
+  return __awaiter(this, void 0, void 0, function () {
+    var _i,
+      API_KEYS_1,
+      key,
+      _c,
+      MODELS_1,
+      model,
+      genAI,
+      _loop_1,
+      attempt,
+      state_1;
+    return __generator(this, function (_d) {
+      switch (_d.label) {
+        case 0:
+          (_i = 0), (API_KEYS_1 = API_KEYS);
+          _d.label = 1;
+        case 1:
+          if (!(_i < API_KEYS_1.length)) return [3 /*break*/, 8];
+          key = API_KEYS_1[_i];
+          (_c = 0), (MODELS_1 = MODELS);
+          _d.label = 2;
+        case 2:
+          if (!(_c < MODELS_1.length)) return [3 /*break*/, 7];
+          model = MODELS_1[_c];
+          genAI = new generative_ai_1.GoogleGenerativeAI(
+            key,
+          ).getGenerativeModel({
+            model: model,
+            systemInstruction: SYSTEM,
+          });
+          _loop_1 = function (attempt) {
+            var result, text, err_1;
+            return __generator(this, function (_e) {
+              switch (_e.label) {
+                case 0:
+                  _e.trys.push([0, 2, , 5]);
+                  return [
+                    4 /*yield*/,
+                    genAI.generateContent({
+                      contents: [
+                        {
+                          role: "user",
+                          parts: [
+                            { text: "Summarize briefly:\n\n".concat(article) },
+                          ],
+                        },
+                      ],
+                      generationConfig: generationConfig,
+                      safetySettings: safetySettings,
+                    }),
+                  ];
+                case 1:
+                  result = _e.sent();
+                  text =
+                    (_b =
+                      (_a =
+                        result === null || result === void 0
+                          ? void 0
+                          : result.response) === null || _a === void 0
+                        ? void 0
+                        : _a.text) === null || _b === void 0
+                      ? void 0
+                      : _b.call(_a).trim();
+                  if (!text) throw new Error("Empty Gemini response");
+                  return [2 /*return*/, { value: text }];
+                case 2:
+                  err_1 = _e.sent();
+                  if (
+                    !(
+                      (isRateOrQuota(err_1) || isOverloaded(err_1)) &&
+                      attempt < MAX_RETRIES_PER_PAIR
+                    )
+                  )
+                    return [3 /*break*/, 4];
+                  return [
+                    4 /*yield*/,
+                    new Promise(function (r) {
+                      return setTimeout(r, BACKOFF_MS * attempt);
+                    }),
+                  ];
+                case 3:
+                  _e.sent();
+                  return [2 /*return*/, "continue"];
+                case 4:
+                  return [3 /*break*/, 5];
+                case 5:
+                  return [2 /*return*/];
+              }
+            });
+          };
+          attempt = 1;
+          _d.label = 3;
+        case 3:
+          if (!(attempt <= MAX_RETRIES_PER_PAIR)) return [3 /*break*/, 6];
+          return [5 /*yield**/, _loop_1(attempt)];
+        case 4:
+          state_1 = _d.sent();
+          if (typeof state_1 === "object") return [2 /*return*/, state_1.value];
+          _d.label = 5;
+        case 5:
+          attempt++;
+          return [3 /*break*/, 3];
+        case 6:
+          _c++;
+          return [3 /*break*/, 2];
+        case 7:
+          _i++;
+          return [3 /*break*/, 1];
+        case 8:
+          throw new Error("All keys/models exhausted while summarizing");
+      }
+    });
+  });
+}
+exports.summarizeContent = summarizeContent;

--- a/crawler/services/topicExtractor.service.js
+++ b/crawler/services/topicExtractor.service.js
@@ -1,0 +1,360 @@
+"use strict";
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator["throw"](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === "function" &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError("Generator is already executing.");
+      while ((g && ((g = 0), op[0] && (_ = 0)), _))
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y["return"]
+                  : op[0]
+                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                    : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.extractTopics = void 0;
+var generative_ai_1 = require("@google/generative-ai");
+var dotenv = require("dotenv");
+dotenv.config();
+/* ── key / model rotation ── */
+var API_KEYS = [
+  process.env.GOOGLE_AI_API_KEY,
+  process.env.GOOGLE_AI_API_KEY1,
+  process.env.GOOGLE_AI_API_KEY2,
+  process.env.GOOGLE_AI_API_KEY3,
+].filter(Boolean);
+var MODELS = ["gemini-2.0-flash", "gemini-2.0-flash-lite", "gemini-1.5-flash"];
+var MAX_RETRIES_PER_PAIR = 2;
+var BACKOFF_MS = 1500;
+/* ── params ── */
+var SYSTEM = (
+  (_a = process.env.AI_INSTRUCTIONS) !== null && _a !== void 0 ? _a : ""
+).trim();
+var generationConfig = {
+  temperature: 0.7,
+  topP: 0.9,
+  topK: 40,
+  maxOutputTokens: 1024,
+};
+var safetySettings = [
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_HARASSMENT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+  {
+    category: generative_ai_1.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+    threshold: generative_ai_1.HarmBlockThreshold.BLOCK_NONE,
+  },
+];
+var MAX_CONTENT_CHARS = 2000;
+/* ── helpers ── */
+/**
+ * Create a prompt for the AI model.
+ *
+ * @param text - The input text to extract topics from.
+ * @returns The formatted prompt string.
+ */
+var makePrompt = function (text) {
+  return (
+    "Extract 5\u201110 concise topics from the following text. " +
+    "Return as a comma\u2011separated list (no quotes/brackets):\n\n".concat(
+      text,
+    )
+  );
+};
+/**
+ * Clean and deduplicate a string.
+ *
+ * @param s - The input string to clean.
+ */
+var clean = function (s) {
+  return Array.from(
+    new Set(
+      s
+        .split(/[\n,]+/)
+        .map(function (t) {
+          return t.trim().toLowerCase();
+        })
+        .filter(Boolean),
+    ),
+  );
+};
+/**
+ * Check if the error is a rate limit error.
+ *
+ * @param e - The error object to check.
+ */
+var isRate = function (e) {
+  return (
+    (e === null || e === void 0 ? void 0 : e.status) === 429 ||
+    /quota|rate/i.test((e === null || e === void 0 ? void 0 : e.message) || "")
+  );
+};
+/**
+ * Check if the error is a server overload or unavailable error.
+ *
+ * @param e - The error object to check.
+ */
+var isOverload = function (e) {
+  return (
+    (e === null || e === void 0 ? void 0 : e.status) === 503 ||
+    /overload|unavailable/i.test(
+      (e === null || e === void 0 ? void 0 : e.message) || "",
+    )
+  );
+};
+/**
+ * Extract topics from a given text using Google Generative AI.
+ *
+ * @param raw - The raw text to extract topics from.
+ */
+function extractTopics(raw) {
+  var _a, _b;
+  return __awaiter(this, void 0, void 0, function () {
+    var content,
+      _i,
+      API_KEYS_1,
+      key,
+      _c,
+      MODELS_1,
+      model,
+      genAI,
+      _loop_1,
+      attempt,
+      state_1;
+    return __generator(this, function (_d) {
+      switch (_d.label) {
+        case 0:
+          content =
+            raw.length > MAX_CONTENT_CHARS
+              ? raw.slice(0, MAX_CONTENT_CHARS) + "…"
+              : raw;
+          (_i = 0), (API_KEYS_1 = API_KEYS);
+          _d.label = 1;
+        case 1:
+          if (!(_i < API_KEYS_1.length)) return [3 /*break*/, 8];
+          key = API_KEYS_1[_i];
+          (_c = 0), (MODELS_1 = MODELS);
+          _d.label = 2;
+        case 2:
+          if (!(_c < MODELS_1.length)) return [3 /*break*/, 7];
+          model = MODELS_1[_c];
+          genAI = new generative_ai_1.GoogleGenerativeAI(
+            key,
+          ).getGenerativeModel({
+            model: model,
+            systemInstruction: SYSTEM,
+          });
+          _loop_1 = function (attempt) {
+            var result, out, err_1;
+            return __generator(this, function (_e) {
+              switch (_e.label) {
+                case 0:
+                  _e.trys.push([0, 2, , 5]);
+                  return [
+                    4 /*yield*/,
+                    genAI.generateContent({
+                      contents: [
+                        {
+                          role: "user",
+                          parts: [{ text: makePrompt(content) }],
+                        },
+                      ],
+                      generationConfig: generationConfig,
+                      safetySettings: safetySettings,
+                    }),
+                  ];
+                case 1:
+                  result = _e.sent();
+                  out =
+                    (_b =
+                      (_a =
+                        result === null || result === void 0
+                          ? void 0
+                          : result.response) === null || _a === void 0
+                        ? void 0
+                        : _a.text) === null || _b === void 0
+                      ? void 0
+                      : _b.call(_a).trim();
+                  if (!out) throw new Error("Empty Gemini response");
+                  return [2 /*return*/, { value: clean(out) }];
+                case 2:
+                  err_1 = _e.sent();
+                  if (
+                    !(
+                      (isRate(err_1) || isOverload(err_1)) &&
+                      attempt < MAX_RETRIES_PER_PAIR
+                    )
+                  )
+                    return [3 /*break*/, 4];
+                  return [
+                    4 /*yield*/,
+                    new Promise(function (r) {
+                      return setTimeout(r, BACKOFF_MS * attempt);
+                    }),
+                  ];
+                case 3:
+                  _e.sent();
+                  return [2 /*return*/, "continue"];
+                case 4:
+                  return [3 /*break*/, 5];
+                case 5:
+                  return [2 /*return*/];
+              }
+            });
+          };
+          attempt = 1;
+          _d.label = 3;
+        case 3:
+          if (!(attempt <= MAX_RETRIES_PER_PAIR)) return [3 /*break*/, 6];
+          return [5 /*yield**/, _loop_1(attempt)];
+        case 4:
+          state_1 = _d.sent();
+          if (typeof state_1 === "object") return [2 /*return*/, state_1.value];
+          _d.label = 5;
+        case 5:
+          attempt++;
+          return [3 /*break*/, 3];
+        case 6:
+          _c++;
+          return [3 /*break*/, 2];
+        case 7:
+          _i++;
+          return [3 /*break*/, 1];
+        case 8:
+          throw new Error("All keys/models exhausted while extracting topics");
+      }
+    });
+  });
+}
+exports.extractTopics = extractTopics;

--- a/crawler/utils/logger.ts
+++ b/crawler/utils/logger.ts
@@ -1,12 +1,9 @@
-import winston from "winston";
+import { createLogger, format, transports } from "winston";
 
-const logger = winston.createLogger({
+const logger = createLogger({
   level: "info",
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.json(),
-  ),
-  transports: [new winston.transports.Console()],
+  format: format.combine(format.timestamp(), format.json()),
+  transports: [new transports.Console()],
 });
 
 export default logger;

--- a/daily.log
+++ b/daily.log
@@ -5093,3 +5093,165 @@ npmnpm ERR!   in workspace: government-article-curator-crawler@1.0.0 ERR!   in w
  
 npm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawlernpm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler 
  
+----------------------------------------
+----------------------------------------
+Daily run started at 2025-08-27 16:00:01
+Daily run started at 2025-08-27 16:00:01
+This script is meant to run daily to complete the following tasks:
+This script is meant to run daily to complete the following tasks:
+
+
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+npm npm ERR! Lifecycle script `crawl` failed with error: 
+ERR! Lifecycle script `crawl` failed with error: 
+npm ERR! Error: command failednpm ERR! Error: command failed 
+ 
+npmnpm ERR!   in workspace: government-article-curator-crawler@1.0.0 
+ ERR!   in workspace: government-article-curator-crawler@1.0.0 
+npm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawlernpm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler 
+ 
+----------------------------------------
+----------------------------------------
+Daily run started at 2025-08-30 16:00:01
+Daily run started at 2025-08-30 16:00:01
+This script is meant to run daily to complete the following tasks:
+This script is meant to run daily to complete the following tasks:
+
+
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+npm ERR! Lifecycle script `crawl` failed with error:npm ERR! Lifecycle script `crawl` failed with error: 
+ 
+npm ERR! Error: command failednpm ERR! Error: command failed 
+ 
+npmnpm ERR!   in workspace: government-article-curator-crawler@1.0.0 
+ ERR!   in workspace: government-article-curator-crawler@1.0.0 
+npm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawlernpm ERR!   at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler 
+ 
+----------------------------------------
+----------------------------------------
+Daily run started at 2025-09-03 16:00:00
+Daily run started at 2025-09-03 16:00:00
+This script is meant to run daily to complete the following tasks:
+This script is meant to run daily to complete the following tasks:
+
+
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+1. 📡 Running crawler… (cwd: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler)
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+
+> government-article-curator-crawler@1.0.0 crawl
+> npx ts-node schedule/fetchAndSummarize.ts
+
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6
+    format: winston_1.default.format.combine(winston_1.default.format.timestamp(), winston_1.default.format.json()),
+                                     ^
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+TypeError: Cannot read properties of undefined (reading 'combine')
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/utils/logger.js:6:38)
+    at Module._compile (node:internal/modules/cjs/loader:1356:14)
+    at Module.m._compile (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1618:23)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
+    at Object.require.extensions.<computed> [as .js] (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/node_modules/ts-node/src/index.ts:1621:12)
+    at Module.load (node:internal/modules/cjs/loader:1197:32)
+    at Function.Module._load (node:internal/modules/cjs/loader:1013:12)
+    at Module.require (node:internal/modules/cjs/loader:1225:19)
+    at require (node:internal/modules/helpers:177:18)
+    at Object.<anonymous> (/Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler/schedule/fetchAndSummarize.ts:27:1)
+npm ERR! Lifecycle script `crawl` failed with error:npm ERR! Lifecycle script `crawl` failed with error: 
+ 
+npm ERR! Error: command failed 
+npm ERR! Error: command failed 
+npmnpm ERR!   in workspace: government-article-curator-crawler@1.0.0 
+ ERR!   in workspace: government-article-curator-crawler@1.0.0 
+npmnpm ERR! ERR!    at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler  at location: /Users/davidnguyen/WebstormProjects/AI-Gov-Content-Curator/crawler 
+ 

--- a/newsletters/__tests__/cleanup.spec.js
+++ b/newsletters/__tests__/cleanup.spec.js
@@ -1,7 +1,7 @@
 process.env.MONGODB_URI = "mongodb://localhost/test";
 
-jest.mock('dotenv', () => ({ config: () => ({}) }));
-jest.mock('mongoose', () => {
+jest.mock("dotenv", () => ({ config: () => ({}) }));
+jest.mock("mongoose", () => {
   class DummySchema {}
   const fakeCursor = {
     [Symbol.asyncIterator]: () => ({
@@ -10,13 +10,22 @@ jest.mock('mongoose', () => {
   };
   const Article = {
     deleteMany: jest.fn().mockResolvedValue({ deletedCount: 5 }),
-    find: jest.fn().mockReturnValue({ lean: () => ({ cursor: () => fakeCursor }) }),
+    find: jest
+      .fn()
+      .mockReturnValue({ lean: () => ({ cursor: () => fakeCursor }) }),
     bulkWrite: jest.fn(),
   };
   const conn = { readyState: 0 };
   return {
     __esModule: true,
-    default: { Schema: DummySchema, models: {}, model: () => Article, connection: conn, connect: jest.fn(), disconnect: jest.fn() },
+    default: {
+      Schema: DummySchema,
+      models: {},
+      model: () => Article,
+      connection: conn,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    },
     Schema: DummySchema,
     model: () => Article,
     connection: conn,
@@ -25,26 +34,26 @@ jest.mock('mongoose', () => {
   };
 });
 
-const mongoose = require('mongoose').default;
-const Article = mongoose.model('Article');
-const { cleanupArticles } = require('../scripts/cleanData');
+const mongoose = require("mongoose").default;
+const Article = mongoose.model("Article");
+const { cleanupArticles } = require("../scripts/cleanData");
 
-describe('cleanupArticles()', () => {
+describe("cleanupArticles()", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mongoose.connection.readyState = 0;
   });
 
-  it('connects, runs Phase 1 deleteMany, skips bulkWrite, then disconnects', async () => {
+  it("connects, runs Phase 1 deleteMany, skips bulkWrite, then disconnects", async () => {
     await cleanupArticles();
 
-    expect(Article.deleteMany).toHaveBeenCalledTimes(1);    // Phase 1 only
-    expect(Article.bulkWrite).not.toHaveBeenCalled();       // Phases 3–6 are no-ops
+    expect(Article.deleteMany).toHaveBeenCalledTimes(1); // Phase 1 only
+    expect(Article.bulkWrite).not.toHaveBeenCalled(); // Phases 3–6 are no-ops
     expect(mongoose.connect).toHaveBeenCalled();
     expect(mongoose.disconnect).toHaveBeenCalled();
   });
 
-  it('when alreadyConnected, it does not reconnect or disconnect', async () => {
+  it("when alreadyConnected, it does not reconnect or disconnect", async () => {
     mongoose.connection.readyState = 1;
     await cleanupArticles();
 

--- a/newsletters/__tests__/newsletter.spec.js
+++ b/newsletters/__tests__/newsletter.spec.js
@@ -2,51 +2,75 @@ process.env.MONGODB_URI = "mongodb://localhost/test";
 process.env.RESEND_API_KEY = "fake-key";
 process.env.UNSUBSCRIBE_BASE_URL = "http://unsubscribe";
 
-jest.mock('dotenv', () => ({ config: () => ({}) }));
-jest.mock('mongoose', () => {
-  class Schema { constructor() {} set() {} }
+jest.mock("dotenv", () => ({ config: () => ({}) }));
+jest.mock("mongoose", () => {
+  class Schema {
+    constructor() {}
+    set() {}
+  }
   const connection = { readyState: 1 };
   // Stub Article model; we'll override .find in the test
   const fakeArticleModel = { find: jest.fn() };
   const fakeSubModel = {
-    find: jest.fn().mockResolvedValue([{ email: 'a@b.com', lastSentAt: null, save: jest.fn() }]),
+    find: jest
+      .fn()
+      .mockResolvedValue([
+        { email: "a@b.com", lastSentAt: null, save: jest.fn() },
+      ]),
   };
   return {
     __esModule: true,
     default: {
       Schema,
       models: {},
-      model: jest.fn((name) => name === 'Article' ? fakeArticleModel : fakeSubModel),
+      model: jest.fn((name) =>
+        name === "Article" ? fakeArticleModel : fakeSubModel,
+      ),
       connection,
       connect: jest.fn(),
       disconnect: jest.fn(),
     },
     Schema,
-    model: jest.fn((name) => name === 'Article' ? fakeArticleModel : fakeSubModel),
+    model: jest.fn((name) =>
+      name === "Article" ? fakeArticleModel : fakeSubModel,
+    ),
     connection,
     connect: jest.fn(),
     disconnect: jest.fn(),
   };
 });
-jest.mock('../scripts/cleanData', () => ({ cleanupArticles: jest.fn().mockResolvedValue() }));
+jest.mock("../scripts/cleanData", () => ({
+  cleanupArticles: jest.fn().mockResolvedValue(),
+}));
 const sendMock = jest.fn().mockResolvedValue({ error: null });
-jest.mock('resend', () => ({ __esModule: true, Resend: jest.fn(() => ({ emails: { send: sendMock } })) }));
+jest.mock("resend", () => ({
+  __esModule: true,
+  Resend: jest.fn(() => ({ emails: { send: sendMock } })),
+}));
 
-const { sendNewsletter } = require('../schedule/sendNewsletter');
-const mongoose = require('mongoose').default;
-const Article = mongoose.model('Article');
+const { sendNewsletter } = require("../schedule/sendNewsletter");
+const mongoose = require("mongoose").default;
+const Article = mongoose.model("Article");
 
-describe('sendNewsletter()', () => {
+describe("sendNewsletter()", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('pulls subscribers, sends at least one email, and disconnects', async () => {
+  it("pulls subscribers, sends at least one email, and disconnects", async () => {
     // Arrange: simulate one new article since lastSentAt
     Article.find.mockReturnValue({
       sort: () => ({
         limit: () => ({
-          lean: () => [{ url:'u', title:'t', summary:'s', fetchedAt: new Date(), source:'src' }],
+          lean: () => [
+            {
+              url: "u",
+              title: "t",
+              summary: "s",
+              fetchedAt: new Date(),
+              source: "src",
+            },
+          ],
         }),
       }),
     });
@@ -59,7 +83,7 @@ describe('sendNewsletter()', () => {
     expect(mongoose.disconnect).toHaveBeenCalled();
   });
 
-  it('throws if RESEND_API_KEY missing', async () => {
+  it("throws if RESEND_API_KEY missing", async () => {
     delete process.env.RESEND_API_KEY;
     await expect(sendNewsletter()).rejects.toThrow(/RESEND_API_KEY missing/);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "typescript": "^4.8.0"
       },
       "engines": {
-        "node": "18.x"
+        "node": "22.x"
       }
     },
     "backend/node_modules/@types/node": {
@@ -162,7 +162,7 @@
         "typescript": "^4.8.0"
       },
       "engines": {
-        "node": "18.x"
+        "node": "22.x"
       }
     },
     "crawler/node_modules/@jest/expect-utils": {


### PR DESCRIPTION
## Description

This PR addresses a hard-fail in the crawler startup caused by a Winston import/interop problem and a stale compiled JS artifact being loaded before the TS module.

**What is the problem this PR is solving?**

* Daily/adhoc runs crashed on startup with:

  ```
  TypeError: Cannot read properties of undefined (reading 'combine')
  at crawler/utils/logger.js:6
  ```

  Root causes:

  1. TS default import of a CommonJS module (`import winston from "winston"`) produced `winston_1.default`, leaving `format` undefined at runtime.
  2. A compiled `utils/logger.js` existed and was being resolved before `logger.ts`, so the broken code path persisted even when TS was correct.

* Secondary issues uncovered while fixing/triaging:

  * Some Jest tests relied on loose object shape expectations; tightened/normalized.
  * Minor test and config nits across workspaces (spacing/formatting, matchers).
  * Crawler services needed clearer key rotation/backoff and stricter filtering of static/anchor URLs from NewsAPI results.

**How did you solve it?**

* **Logger fix (core):**

  * Switched to CJS-safe named imports and usage.

    ```ts
    // crawler/utils/logger.ts
    import { createLogger, format, transports } from "winston";

    const logger = createLogger({
      level: "info",
      format: format.combine(format.timestamp(), format.json()),
      transports: [new transports.Console()],
    });

    export default logger;
    ```
  * Removed reliance on any default import semantics; no tsconfig changes required.
  * Ensured we don’t ship/run a stale `utils/logger.js` that shadows the TS module.

* **Crawler/runtime resilience:**

  * Added/confirmed **key rotation** and **backoff** for NewsAPI + Gemini calls.
  * Filtered out static assets/anchors early (`STATIC_EXT_RE`) to reduce wasted fetches.
  * Consolidated summarize/topic extraction with model rotation and basic truncation.

* **Tests & configs:**

  * Tightened controller tests (backend) to assert full payload shapes where useful.
  * Normalized mocks and expectations for newsletter/comment/user controllers.
  * Minor Jest config cleanups (harmless formatting).
  * Added/updated crawler unit tests for static/dynamic fetch paths and NewsAPI paging/filtering.

* **Housekeeping:**

  * `.prettierignore` update to avoid committing build artifacts (`backend/dist`).
  * Added a thin API wrapper for scheduled runs under `crawler/pages/api/scheduled/fetchAndSummarize.js`.

---

## Related Issue

[AICC-34](https://ai-content-curator.atlassian.net/browse/AICC-34)

---

## Type of Change

* 🐛 Bug fix (non-breaking change which fixes an issue)
* ✅ Test addition or enhancement
* 🧹 Chore (build process, CI, tooling, etc)

---

## Which Workspace(s) Does This Affect?

* [ ] `frontend`
* [x] `backend`
* [x] `crawler`
* [ ] `bin` / CLI
* [x] `newsletters`
* [ ] `.github` / GitHub Actions
* [ ] `shell` / scripts
* [x] Root / tooling
* [ ] Other (please specify)

---

## Checklist

* [x] I have read the **contributing guidelines**.
* [x] My code follows the existing **style guide** (lint, formatting).
* [x] I have added or updated **unit tests** for new functionality.
* [ ] I have added or updated **end-to-end tests** where applicable.
* [x] I have added or updated **documentation** (inline comments, PR notes).
* [x] I have run the full **test suite** locally.
* [x] I have tested my changes in **development** builds.
* [x] Any dependent changes have been merged/published in downstream modules.

---

## How Has This Been Tested?

Repro (pre-fix):

```bash
cd crawler
npm run crawl
# ❌ crashes with "winston_1.default.format" undefined from utils/logger.js
```

Validation (post-fix):

```bash
# from repo root
npm ci

# run unit tests across workspaces
npm --workspaces run test

# crawler smoke
npm --workspace crawler run crawl
# ✅ connects to Mongo, crawls, summarizes, upserts, cleans up
```

Notes:

* Verified the process no longer resolves a stale `utils/logger.js` and that Winston `format.combine(...)` executes.

* Confirmed NewsAPI paging + filtering returns only non-static, non-anchor URLs.

* Confirmed summarization/topic extraction rotate keys/models and back off on 429/503.

* [x] Unit tests

* [x] Integration-ish controller tests

* [ ] End-to-end tests

* [x] Manual testing steps (above)

---

## Screenshots (if appropriate)

N/A (backend/crawler change)

---

## Deployment Notes

* **Env vars:** no new required variables.

  * Optional: `AI_INSTRUCTIONS` (system prompt for Gemini) is read if present.
  * Existing keys used/rotated:

    * `GOOGLE_AI_API_KEY`, `GOOGLE_AI_API_KEY1..N`
    * `NEWS_API_KEY`, `NEWS_API_KEY1..N`

* Ensure production/cron environments **do not ship** stale compiled `crawler/utils/logger.js` files that could shadow TS.

---

## Rollback Plan

* Revert this PR.
* If a regression is observed, re-introduce the previous logger, and disable the scheduled crawler job until the interop is corrected.

---

Thank you for the review! 🙌


[AICC-34]: https://ai-content-curator.atlassian.net/browse/AICC-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ