### PR TITLE
feat(ui): enhance responsive UI of app [AICC-44]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SynthoraAI - AI-Powered Article Content Curator
 
-> [!TIP] 
+> [!TIP]
 > **SynthoraAI - Synthesizing the world’s news & information through AI.** 🚀✨
 
 The **SynthoraAI - AI-Powered Article Content Curator** is a comprehensive, AI-powered system designed to aggregate, summarize, and present curated government-related articles.

--- a/frontend/components/AllArticles.tsx
+++ b/frontend/components/AllArticles.tsx
@@ -53,7 +53,7 @@ export default function AllArticles() {
 
     for (let i = 0; i < items.length; i += itemsPerCarousel) {
       const chunk = items.slice(i, i + itemsPerCarousel);
-      
+
       // If this is the last chunk and has less than min items, merge with previous
       if (chunk.length < minItemsPerCarousel && carousels.length > 0) {
         carousels[carousels.length - 1].push(...chunk);

--- a/frontend/components/LatestArticles.tsx
+++ b/frontend/components/LatestArticles.tsx
@@ -27,7 +27,7 @@ export default function LatestArticles({
 
   // 3) Split articles into two groups for two carousels, ensuring min 3 per carousel
   const minItemsPerCarousel = 3;
-  
+
   // If total articles is less than min*2, show all in one carousel
   if (articles.length < minItemsPerCarousel * 2) {
     return (
@@ -40,7 +40,7 @@ export default function LatestArticles({
       </div>
     );
   }
-  
+
   const midPoint = Math.ceil(articles.length / 2);
   const firstHalf = articles.slice(0, midPoint);
   const secondHalf = articles.slice(midPoint);

--- a/frontend/pages/home.tsx
+++ b/frontend/pages/home.tsx
@@ -2,6 +2,7 @@ import { GetStaticProps } from "next";
 import Head from "next/head";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import { MdSearch } from "react-icons/md";
 import LatestArticles from "../components/LatestArticles";
 import AllArticles from "../components/AllArticles";
 import ArticleSearch from "../components/ArticleSearch";
@@ -68,22 +69,25 @@ export default function HomePage({
       </Head>
       <div style={{ marginBottom: "2rem", marginTop: "2rem" }}>
         <div className="search-container fade-down">
-          <input
-            type="text"
-            placeholder="Search articles..."
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              router.push(
-                `/home?q=${encodeURIComponent(
-                  e.target.value,
-                )}&topic=${encodeURIComponent(selectedTopic)}`,
-                undefined,
-                { shallow: true },
-              );
-            }}
-            className="search-input"
-          />
+          <div className="search-input-wrapper">
+            <MdSearch className="search-icon" size={24} />
+            <input
+              type="text"
+              placeholder="Search articles..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                router.push(
+                  `/home?q=${encodeURIComponent(
+                    e.target.value,
+                  )}&topic=${encodeURIComponent(selectedTopic)}`,
+                  undefined,
+                  { shallow: true },
+                );
+              }}
+              className="search-input"
+            />
+          </div>
           {/* @ts-ignore */}
           <TopicDropdown
             selectedTopic={selectedTopic}

--- a/frontend/styles/article-search.css
+++ b/frontend/styles/article-search.css
@@ -30,8 +30,29 @@
   align-items: center;
 }
 
+.search-input-wrapper {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 1rem;
+  color: var(--text-color);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 1;
+}
+
 .search-input {
   flex: 1;
+  padding-left: 3rem;
+}
+
+.search-input:focus {
+  transform: none;
 }
 
 /* ---------- Article Search Results ---------- */

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -25,7 +25,8 @@ body {
 main {
   min-height: calc(100vh - 120px); /* account for navbar + footer */
   padding: 1rem;
-  max-width: 900px;
+  width: 95%;
+  max-width: 95%;
   margin: 0 auto;
 }
 

--- a/frontend/styles/landing.css
+++ b/frontend/styles/landing.css
@@ -294,13 +294,16 @@ h2 {
 
 /* Features */
 .features {
-  padding: 4rem 2rem;
+  padding: 4rem 1rem;
   background: var(--bg-color);
 }
 .feature-grid {
   display: grid;
   gap: 2rem;
-  padding: 0 2rem;
+  padding: 0 1rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   justify-content: center;
 }
@@ -337,7 +340,7 @@ h2 {
 
 /* Stats */
 .stats {
-  padding: 4rem 2rem;
+  padding: 4rem 1rem;
   background: var(--hover-bg);
 }
 .stats-grid {
@@ -345,6 +348,9 @@ h2 {
   flex-wrap: wrap;
   justify-content: center;
   gap: 2rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
 }
 .stat-card {
   background: var(--card-bg);
@@ -391,6 +397,9 @@ h2 {
   display: grid;
   gap: 2rem;
   padding: 0 1rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   justify-content: center;
 }
@@ -440,10 +449,12 @@ h2 {
 
 /* FAQ */
 .faq {
-  padding: 4rem 2rem;
+  padding: 4rem 1rem;
   background: var(--hover-bg);
 }
 .faq-list {
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
   padding: 0 1rem;
 }
@@ -490,7 +501,8 @@ details p {
 
 /* Partners */
 .container {
-  max-width: 1200px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
   padding: 0 1rem;
 }
@@ -506,6 +518,9 @@ details p {
   align-items: center;
   justify-items: center;
   padding: 0 1rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
 }
 .partner-logo {
   width: 100%;
@@ -535,7 +550,7 @@ details p {
 
 /* Contact */
 .contact {
-  padding: 4rem 2rem;
+  padding: 4rem 1rem;
   background: var(--hover-bg);
   text-align: center;
   margin-bottom: 2rem;
@@ -553,7 +568,10 @@ details p {
 .contact-grid {
   display: grid;
   gap: 2rem;
-  padding: 0 2rem;
+  padding: 0 1rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   justify-items: center;
 }
@@ -610,7 +628,7 @@ details p {
 
 /* Final CTA */
 .final-cta {
-  padding: 4rem 2rem;
+  padding: 4rem 1rem;
   background: linear-gradient(90deg, var(--accent-color), #45a1ff);
   color: #fff;
   text-align: center;
@@ -630,6 +648,10 @@ details p {
   justify-content: center;
   gap: 1rem;
   margin-top: 1.5rem;
+  width: 100%;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 .final-cta .btn.outline {
   border-color: #fff;

--- a/frontend/styles/navbar.css
+++ b/frontend/styles/navbar.css
@@ -14,7 +14,8 @@ header.navbar-container {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 1200px;
+  width: 95%;
+  max-width: 95%;
   margin: 0 auto;
   padding: 0.75rem 1rem;
   position: relative;


### PR DESCRIPTION
This pull request improves the search input UI and enhances responsive design across the landing and main pages. The most significant changes include adding a search icon to the article search bar, updating related styles for better alignment and usability, and making layout containers and grids more fluid and consistent across different screen sizes.

**Search Input UI Enhancements:**

* Added a search icon (`MdSearch`) inside the article search input for better user experience, with corresponding wrapper and icon styling for proper alignment and appearance. (`frontend/pages/home.tsx` [[1]](diffhunk://#diff-2ab51ec0debfdacc5976012a233f21207d42fdd393dce5239a3d0ece42fe2282R5) [[2]](diffhunk://#diff-2ab51ec0debfdacc5976012a233f21207d42fdd393dce5239a3d0ece42fe2282R72-R73) [[3]](diffhunk://#diff-2ab51ec0debfdacc5976012a233f21207d42fdd393dce5239a3d0ece42fe2282R90); `frontend/styles/article-search.css` [[4]](diffhunk://#diff-d40d9e476c3a7926884c14eb10cd1aa2bf39ec55a9f170579e383883ebfd23e2R33-R55)

**Responsive Layout Improvements:**

* Updated main content container and navigation bar to use percentage-based widths (`width: 95%`, `max-width: 95%`) for improved responsiveness. (`frontend/styles/globals.css` [[1]](diffhunk://#diff-f496ea841303b8b9840718470a17ec23a0a14b83237793a507b585258e88f534L28-R29); `frontend/styles/navbar.css` [[2]](diffhunk://#diff-6bb8101fd391a4d93bfd09a2f83ceb8e5901b92c547fce3cfadf815a81cb7905L17-R18)
* Adjusted padding and max-width for multiple sections on the landing page (features, stats, FAQ, partners, contact, and final CTA) to use `width: 100%` and smaller horizontal padding, ensuring consistency and better display on all devices. (`frontend/styles/landing.css` [[1]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L297-R306) [[2]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L340-R353) [[3]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519R400-R402) [[4]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L443-R457) [[5]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L493-R505) [[6]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519R521-R523) [[7]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L538-R553) [[8]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L556-R574) [[9]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519L613-R631) [[10]](diffhunk://#diff-40ad9d6738f44d16b77bf947a25d199e3f1c8e3016b42816dad23f759a524519R651-R654)