### PR TITLE
Add cron job installation script and sync vectors script [AICC-44]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .env
 .vercel
 daily.log
+sync_vectors.log

--- a/install_sync_cron.sh
+++ b/install_sync_cron.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# install_sync_cron.sh
+# ---------------------------------------------------------------
+# Adds cron entries to run `sync_vectors.sh` 5 times daily:
+# - 5:00 AM
+# - 11:00 AM
+# - 2:00 PM
+# - 5:00 PM
+# - 10:00 PM
+# ---------------------------------------------------------------
+# How to use:
+# 1. Make it executable: chmod +x install_sync_cron.sh
+# 2. Run it once: ./install_sync_cron.sh
+# 3. Check the crontab: crontab -l
+# ---------------------------------------------------------------
+
+# SCRIPT:
+# 1. Resolve the absolute path to `sync_vectors.sh`
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC_SH="${SCRIPT_DIR}/sync_vectors.sh"
+LOGFILE="${SCRIPT_DIR}/sync_vectors.log"
+
+# 2. Make sure sync_vectors.sh is executable
+chmod +x "$SYNC_SH"
+
+# 3. Define the cron lines (using absolute paths)
+#          ┌──────── minute
+#          │ ┌────── hour
+#          │ │ ┌──── day of month (*)
+#          │ │ │ ┌── month (*)
+#          │ │ │ │ ┌ day of week (*)
+#          │ │ │ │ │
+CRON_05AM="0 5 * * * cd $SCRIPT_DIR && $SYNC_SH >> $LOGFILE 2>&1"
+CRON_11AM="0 11 * * * cd $SCRIPT_DIR && $SYNC_SH >> $LOGFILE 2>&1"
+CRON_02PM="0 14 * * * cd $SCRIPT_DIR && $SYNC_SH >> $LOGFILE 2>&1"
+CRON_05PM="0 17 * * * cd $SCRIPT_DIR && $SYNC_SH >> $LOGFILE 2>&1"
+CRON_10PM="0 22 * * * cd $SCRIPT_DIR && $SYNC_SH >> $LOGFILE 2>&1"
+
+# 4. Install them (remove old entries first, then add new ones)
+#    - list existing crons (or empty)
+#    - filter out any old sync_vectors.sh lines
+#    - append our new lines
+{
+  crontab -l 2>/dev/null | grep -v -F "sync_vectors.sh"
+  echo "0 5 * * * cd \"$SCRIPT_DIR\" && \"$SYNC_SH\" >> \"$LOGFILE\" 2>&1"
+  echo "0 11 * * * cd \"$SCRIPT_DIR\" && \"$SYNC_SH\" >> \"$LOGFILE\" 2>&1"
+  echo "0 14 * * * cd \"$SCRIPT_DIR\" && \"$SYNC_SH\" >> \"$LOGFILE\" 2>&1"
+  echo "0 17 * * * cd \"$SCRIPT_DIR\" && \"$SYNC_SH\" >> \"$LOGFILE\" 2>&1"
+  echo "0 22 * * * cd \"$SCRIPT_DIR\" && \"$SYNC_SH\" >> \"$LOGFILE\" 2>&1"
+} | crontab -
+
+echo "✅ Cron jobs installed. Sync will run at:"
+echo "   - 5:00 AM"
+echo "   - 11:00 AM"
+echo "   - 2:00 PM"
+echo "   - 5:00 PM"
+echo "   - 10:00 PM"
+echo ""
+echo "📝 Logs will be written to: $LOGFILE"
+echo ""
+echo "To verify, run: crontab -l"

--- a/sync_vectors.sh
+++ b/sync_vectors.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── Load NVM so npm/node are on the PATH ───
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+else
+  echo "⚠️  Warning: nvm not found at $NVM_DIR; ensure Node is on PATH" >&2
+fi
+
+# ─── Bootstrap into the script's own directory ───
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/backend"
+
+LOGFILE="$SCRIPT_DIR/sync_vectors.log"
+
+echo "----------------------------------------" | tee -a "$LOGFILE"
+echo "Sync vectors started at $(date +"%Y-%m-%d %H:%M:%S")" | tee -a "$LOGFILE"
+echo "" | tee -a "$LOGFILE"
+
+# Run the sync script
+npm install --silent               2>&1 | tee -a "$LOGFILE"
+npm run sync-missing-vectors      2>&1 | tee -a "$LOGFILE"
+
+echo "" | tee -a "$LOGFILE"
+echo "Sync vectors finished at $(date +"%Y-%m-%d %H:%M:%S")" | tee -a "$LOGFILE"
+echo "----------------------------------------" | tee -a "$LOGFILE"


### PR DESCRIPTION
This pull request introduces automation for running the `sync_vectors.sh` script on a regular schedule and ensures consistent logging and environment setup. The main changes are the addition of two scripts: one to install cron jobs for scheduled execution and another to perform the sync operation with proper environment preparation and logging.

**Automation and Scheduling:**

* Added a new script, `install_sync_cron.sh`, which installs five daily cron jobs to execute `sync_vectors.sh` at specified times (5:00 AM, 11:00 AM, 2:00 PM, 5:00 PM, and 10:00 PM). The script ensures old cron entries are removed before adding the new ones and provides clear instructions and confirmation messages.

**Sync Script Improvements:**

* Introduced `sync_vectors.sh`, which:
  * Loads NVM to ensure Node.js and npm are available.
  * Changes to the correct working directory before running commands.
  * Logs output and timestamps to a dedicated log file.
  * Runs `npm install` and `npm run sync-missing-vectors` with output appended to the log for traceability and debugging.