### PR TITLE
Fix article summary overflow in search results and article cards [AICC-44]

### DIFF
--- a/frontend/components/ArticleCarousel.tsx
+++ b/frontend/components/ArticleCarousel.tsx
@@ -66,6 +66,21 @@ export default function ArticleCarousel({
       .catch((err) => {
         console.error("Error loading favorites", err);
       });
+
+    // Listen for cache updates from other components
+    const handleCustomEvent = (e: Event) => {
+      const customEvent = e as CustomEvent;
+      if (customEvent.detail?.favIds) {
+        cachedFavIds = customEvent.detail.favIds;
+        setFavoriteIds(new Set(customEvent.detail.favIds));
+      }
+    };
+
+    window.addEventListener("favCacheUpdated", handleCustomEvent);
+
+    return () => {
+      window.removeEventListener("favCacheUpdated", handleCustomEvent);
+    };
   }, []);
 
   const truncateSummary = (text: string, maxLength: number = 250) => {
@@ -133,6 +148,13 @@ export default function ArticleCarousel({
             cachedFavIds = cachedFavIds.filter((id) => id !== articleId);
           }
           localStorage.setItem("favIds", JSON.stringify(cachedFavIds));
+
+          // Dispatch custom event to notify other components
+          window.dispatchEvent(
+            new CustomEvent("favCacheUpdated", {
+              detail: { favIds: cachedFavIds },
+            }),
+          );
         }
 
         return next;

--- a/frontend/pages/favorites/favorites.tsx
+++ b/frontend/pages/favorites/favorites.tsx
@@ -24,6 +24,17 @@ export default function FavoritesPage() {
       try {
         const data = await fetchFavoriteArticles(token);
         setFavoriteArticles(data);
+
+        // Update the cache with the fresh list of favorite IDs
+        const favIds = data.map((article: Article) => article._id);
+        localStorage.setItem("favIds", JSON.stringify(favIds));
+
+        // Dispatch custom event to notify other components
+        window.dispatchEvent(
+          new CustomEvent("favCacheUpdated", {
+            detail: { favIds },
+          }),
+        );
       } catch (error) {
         console.error(
           error instanceof Error ? error.message : "An error occurred.",

--- a/frontend/styles/article-carousel.css
+++ b/frontend/styles/article-carousel.css
@@ -179,6 +179,21 @@
   .article-carousel-section {
     display: none;
   }
+
+  .mobile-grid .article-summary {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+    word-break: break-word;
+  }
+
+  .mobile-grid .article-summary * {
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
 }
 
 @media (max-width: 640px) {

--- a/frontend/styles/article-search.css
+++ b/frontend/styles/article-search.css
@@ -144,6 +144,34 @@
   animation: slideIn 0.5s ease-out;
 }
 
+/* ---------- Fix Summary Overflow in Search Results ---------- */
+.article-search-results .article-summary {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.article-search-results .article-summary * {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.article-search-results .article-summary p,
+.article-search-results .article-summary h1,
+.article-search-results .article-summary h2,
+.article-search-results .article-summary h3,
+.article-search-results .article-summary h4,
+.article-search-results .article-summary h5,
+.article-search-results .article-summary h6 {
+  margin: 0 !important;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 /* ---------- Dropdown Styles (Topic Dropdown) ---------- */
 .topic-dropdown-container {
   position: relative;

--- a/frontend/styles/articles.css
+++ b/frontend/styles/articles.css
@@ -83,6 +83,17 @@
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
   min-height: 0;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.article-summary * {
+  font-size: 0.9rem;
+  color: var(--text-color);
+  opacity: 0.8;
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: break-word;
 }
 
 .article-summary p {
@@ -91,6 +102,7 @@
   opacity: 0.8;
   line-height: 1.5;
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 /* ---------- Article Topics ---------- */
@@ -166,6 +178,18 @@
 }
 
 /* ---------- Markdown Styling in Article Cards ---------- */
+.article-summary h1,
+.article-summary h2,
+.article-summary h3,
+.article-summary h4,
+.article-summary h5,
+.article-summary h6 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0;
+  overflow-wrap: break-word;
+}
+
 .article-summary ul,
 .article-summary ol {
   padding-left: 1.5em;


### PR DESCRIPTION
This pull request improves how article favorite status is synchronized across components and enhances the display of article summaries for better readability and consistency. The main changes are the addition of a custom event system for favorites cache updates, summary truncation, and several CSS fixes to prevent summary overflow.

**Favorites synchronization improvements:**
- Implemented a custom `favCacheUpdated` event to keep favorite status in sync across components (`ArticleCard`, `ArticleCarousel`, and `FavoritesPage`). When the favorites cache is updated, a custom event is dispatched and listened for, ensuring all relevant components reflect the latest state. [[1]](diffhunk://#diff-08a379762f1f0fa270f21862e2ed26ab659b255695a0d9e6a13f00c3bbc5ad9cR72-R100) [[2]](diffhunk://#diff-08a379762f1f0fa270f21862e2ed26ab659b255695a0d9e6a13f00c3bbc5ad9cR118-R124) [[3]](diffhunk://#diff-025712c913a1df02a19a6ff9f17c8b75538b3a6ca69aac88ddce15822084aac2R69-R83) [[4]](diffhunk://#diff-025712c913a1df02a19a6ff9f17c8b75538b3a6ca69aac88ddce15822084aac2R151-R157) [[5]](diffhunk://#diff-154b51c0de1976a454f3ca45b4ffe479d26e0b138458b2315941bc78c586cde5R27-R37)

**Article summary display enhancements:**
- Added a `truncateSummary` helper to limit summary length in `ArticleCard` for a more concise display. [[1]](diffhunk://#diff-08a379762f1f0fa270f21862e2ed26ab659b255695a0d9e6a13f00c3bbc5ad9cR49-R53) [[2]](diffhunk://#diff-08a379762f1f0fa270f21862e2ed26ab659b255695a0d9e6a13f00c3bbc5ad9cL123-R164)
- Improved CSS for `.article-summary` in various contexts (`articles.css`, `article-carousel.css`, `article-search.css`) to prevent overflow, ensure proper word breaking, and standardize markdown heading styles within summaries. [[1]](diffhunk://#diff-ef67ad6e94865c7c39c7527f6b2ae7a2cab1734320c4262e6a7c4817ba6dc956R86-R96) [[2]](diffhunk://#diff-ef67ad6e94865c7c39c7527f6b2ae7a2cab1734320c4262e6a7c4817ba6dc956R105) [[3]](diffhunk://#diff-ef67ad6e94865c7c39c7527f6b2ae7a2cab1734320c4262e6a7c4817ba6dc956R181-R192) [[4]](diffhunk://#diff-48463c6e6c77e00f1f59df7f53bc9694af04abdd3a89ed76432dd66d2d88f68bR182-R196) [[5]](diffhunk://#diff-d40d9e476c3a7926884c14eb10cd1aa2bf39ec55a9f170579e383883ebfd23e2R147-R174)