### PR TITLE
Add tooltip component and integrate it into navigation and theme toggle

### DIFF
--- a/frontend/components/AuthDropdown.tsx
+++ b/frontend/components/AuthDropdown.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import { MdPerson } from "react-icons/md";
 import { validateToken } from "../services/api";
 import { toast } from "react-toastify";
+import Tooltip from "./Tooltip";
 
 interface AuthDropdownProps {
   theme: "light" | "dark" | "system";
@@ -105,13 +106,15 @@ export default function AuthDropdown({
 
   return (
     <div className="auth-dropdown-container" ref={containerRef}>
-      <button
-        className={`auth-toggle-btn${isAuthRoute ? " active-icon" : ""}`}
-        onClick={handleClick}
-        aria-label="User menu"
-      >
-        <MdPerson size={24} />
-      </button>
+      <Tooltip text="Account">
+        <button
+          className={`auth-toggle-btn${isAuthRoute ? " active-icon" : ""}`}
+          onClick={handleClick}
+          aria-label="User menu"
+        >
+          <MdPerson size={24} />
+        </button>
+      </Tooltip>
 
       {open && (
         <div className="auth-dropdown">

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -17,6 +17,7 @@ import "react-toastify/dist/ReactToastify.css";
 
 import ThemeToggle from "./ThemeToggle";
 import AuthDropdown from "./AuthDropdown";
+import Tooltip from "./Tooltip";
 
 const ArticleIcon = MdArticle as React.FC<{ size?: number }>;
 const MailIcon = MdMailOutline as React.FC<{ size?: number }>;
@@ -105,42 +106,48 @@ export default function Navbar({ theme, onThemeChange }: NavbarProps) {
 
         {/* Desktop Nav */}
         <div className="navbar-right">
-          <Link href="/home" legacyBehavior>
-            <a
-              className={`nav-link${router.pathname === "/home" ? " active-link" : ""}`}
-              title="Home"
-            >
-              <MdHome size={24} />
-            </a>
-          </Link>
-          <Link href="/newsletter" legacyBehavior>
-            <a
-              className={`nav-link${router.pathname === "/newsletter" ? " active-link" : ""}`}
-              title="Newsletter"
-            >
-              <MailIcon size={24} />
-            </a>
-          </Link>
-          <Link href="/favorites/favorites" legacyBehavior>
-            <a
-              className={`nav-link${
-                router.pathname === "/favorites/favorites" ? " active-link" : ""
-              }`}
-              title="Favorites"
-            >
-              <MdFavorite size={24} />
-            </a>
-          </Link>
-          <Link href="/ai_chat" legacyBehavior>
-            <a
-              className={`nav-link${
-                router.pathname === "/ai_chat" ? " active-link" : ""
-              }`}
-              title="Ask AI"
-            >
-              <MdSmartToy size={24} />
-            </a>
-          </Link>
+          <Tooltip text="Home">
+            <Link href="/home" legacyBehavior>
+              <a
+                className={`nav-link${router.pathname === "/home" ? " active-link" : ""}`}
+              >
+                <MdHome size={24} />
+              </a>
+            </Link>
+          </Tooltip>
+          <Tooltip text="Newsletter">
+            <Link href="/newsletter" legacyBehavior>
+              <a
+                className={`nav-link${router.pathname === "/newsletter" ? " active-link" : ""}`}
+              >
+                <MailIcon size={24} />
+              </a>
+            </Link>
+          </Tooltip>
+          <Tooltip text="Favorites">
+            <Link href="/favorites/favorites" legacyBehavior>
+              <a
+                className={`nav-link${
+                  router.pathname === "/favorites/favorites"
+                    ? " active-link"
+                    : ""
+                }`}
+              >
+                <MdFavorite size={24} />
+              </a>
+            </Link>
+          </Tooltip>
+          <Tooltip text="Ask AI">
+            <Link href="/ai_chat" legacyBehavior>
+              <a
+                className={`nav-link${
+                  router.pathname === "/ai_chat" ? " active-link" : ""
+                }`}
+              >
+                <MdSmartToy size={24} />
+              </a>
+            </Link>
+          </Tooltip>
 
           <ThemeToggle
             theme={theme}

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import React from "react";
 import { MdDarkMode, MdLightMode, MdSettingsBrightness } from "react-icons/md";
 import { toast } from "react-toastify";
+import Tooltip from "./Tooltip";
 
 const DarkModeIcon = MdDarkMode as React.FC<{ size?: number }>;
 const LightModeIcon = MdLightMode as React.FC<{ size?: number }>;
@@ -121,13 +122,15 @@ export default function ThemeToggle({
 
   return (
     <div style={{ position: "relative" }} ref={containerRef}>
-      <button
-        className="theme-toggle-btn"
-        onClick={handleToggle}
-        aria-label="Toggle theme"
-      >
-        {displayedTheme}
-      </button>
+      <Tooltip text="Theme">
+        <button
+          className="theme-toggle-btn"
+          onClick={handleToggle}
+          aria-label="Toggle theme"
+        >
+          {displayedTheme}
+        </button>
+      </Tooltip>
 
       {open && (
         <div className="theme-dropdown">

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode, useState, useRef, useEffect } from "react";
+
+interface TooltipProps {
+  children: ReactNode;
+  text: string;
+}
+
+export default function Tooltip({ children, text }: TooltipProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, 300); // Delay before showing tooltip
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {isVisible && <div className="tooltip-content">{text}</div>}
+    </div>
+  );
+}

--- a/frontend/styles/navbar.css
+++ b/frontend/styles/navbar.css
@@ -200,6 +200,68 @@ header.navbar-container {
   }
 }
 
+/* Tooltip Styles (Desktop Only) */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip-content {
+  position: absolute;
+  bottom: -2.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--card-border);
+  z-index: 10000;
+  pointer-events: none;
+  animation: tooltipFadeIn 0.2s ease-out forwards;
+}
+
+.tooltip-content::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: var(--card-border);
+}
+
+.tooltip-content::after {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-bottom-color: var(--card-bg);
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+/* Hide tooltip on mobile */
+@media (max-width: 768px) {
+  .tooltip-content {
+    display: none;
+  }
+}
+
 /* Mobile Styles */
 .mobile-dropdown-container {
   display: none;


### PR DESCRIPTION
This pull request introduces a reusable `Tooltip` component to enhance the user interface with accessible tooltips for key navigation and action buttons. The tooltips provide descriptive text on hover, improving usability and accessibility, especially for desktop users. Styles for the tooltip are added to ensure a consistent look and feel, and tooltips are hidden on mobile devices.

**Component Addition**

* Added a new `Tooltip` component in `frontend/components/Tooltip.tsx` that displays a tooltip with a configurable text label on hover, with a delay for better UX.

**UI Enhancements**

* Wrapped navigation buttons in `frontend/components/Navbar.tsx` (`Home`, `Newsletter`, `Favorites`, `Ask AI`) with the new `Tooltip` component, replacing the previous use of the `title` attribute for improved styling and accessibility.
* Wrapped the theme toggle button in `frontend/components/ThemeToggle.tsx` with the `Tooltip` component, providing a descriptive "Theme" label on hover.
* Wrapped the account/user menu button in `frontend/components/AuthDropdown.tsx` with the `Tooltip` component, showing "Account" on hover.

**Styling**

* Added tooltip styles to `frontend/styles/navbar.css`, including positioning, animation, color, and responsive behavior to hide tooltips on mobile devices.

**Imports**

* Imported the new `Tooltip` component in files where it is used: `Navbar.tsx`, `ThemeToggle.tsx`, and `AuthDropdown.tsx`. [[1]](diffhunk://#diff-17575686fb8379b66c8365b3397d220c00006186f2acef2cf20cd38ed9f75da2R20) [[2]](diffhunk://#diff-1935a2591c49c7fb980731881bc4a2fb6de736449f2454fcc71393bf21e47448R7) [[3]](diffhunk://#diff-a345785930f4c5c5dd9a9a78438f370e41a50c4d89369c7146ef3ec8e4e87c99R9)