### PR TITLE
Use Node 20 in frontend Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Copy package files and install dependencies
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Production image
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app
 
 # Copy only production dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in the `frontend/Dockerfile` from 18-alpine to 20-alpine for both the build and production stages. This change ensures the application uses a more recent Node.js version, which can provide improved performance, security, and access to newer language features. No other changes are included.