### PR TITLE
Upgrade to Node 20 in frontend Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Copy package files and install dependencies
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Production image
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /app
 
 # Copy only production dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in the `frontend/Dockerfile` from 18-alpine to 20-alpine for both the build and production stages. This ensures the application uses a more recent, supported Node.js version. 

- Dockerfile environment update:
  * Upgraded the base image for both the builder and production stages from `node:18-alpine` to `node:20-alpine` in `frontend/Dockerfile` [[1]](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L2-R2) [[2]](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L16-R16)

Fixes #67