### PR TITLE
Add loading spinner styles to dropdown; adjust margin and flex properties for better alignment

### DIFF
--- a/frontend/styles/topic-dropdown.css
+++ b/frontend/styles/topic-dropdown.css
@@ -192,6 +192,11 @@
   width: 100%;
 }
 
+.dropdown-loading .spinner {
+  margin: 0;
+  flex-shrink: 0;
+}
+
 .spinner {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
This pull request introduces a minor style improvement to the topic dropdown component. The change ensures that the spinner inside a loading dropdown is properly aligned and does not shrink.

- Style Adjustment:
  * [`frontend/styles/topic-dropdown.css`](diffhunk://#diff-b0345805ea482c3e9ab4fe886b4cfe1d5cb5ecd94ae6a95d22b70edd568142c6R195-R199): Added a CSS rule for `.dropdown-loading .spinner` to set `margin: 0` and `flex-shrink: 0`, improving spinner alignment and preventing it from shrinking in loading dropdowns.