### PR TITLE
Update scroll behavior to target 'purpose-built' section; add ID to highlights section for improved navigation

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -398,7 +398,9 @@ export default function LandingPage() {
   }, []);
 
   const scrollToFeatures = () => {
-    document.getElementById("features")?.scrollIntoView({ behavior: "smooth" });
+    document
+      .getElementById("purpose-built")
+      ?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
@@ -544,7 +546,7 @@ export default function LandingPage() {
           </button>
         </section>
 
-        <section className="highlights">
+        <section id="purpose-built" className="highlights">
           <div className="landing-container">
             <div className="section-head reveal">
               <span className="eyebrow">Purpose built</span>


### PR DESCRIPTION
This pull request updates the landing page to improve navigation to the "Purpose built" highlights section. The main changes include updating the scroll target and adding an ID to the relevant section.

Landing page navigation improvements:

* Changed the `scrollToFeatures` function to scroll to the section with the ID `purpose-built` instead of `features` in `LandingPage` (`frontend/pages/index.tsx`).
* Added an `id="purpose-built"` to the highlights section to enable smooth scrolling to the correct section (`frontend/pages/index.tsx`).