### PR TITLE
Update translation help message to clarify loading issues and translation availability

### DIFF
--- a/frontend/components/TranslateDropdown.tsx
+++ b/frontend/components/TranslateDropdown.tsx
@@ -26,7 +26,9 @@ export default function TranslateDropdown({
   const slotRef = useRef<HTMLDivElement>(null);
 
   const handleToggle = () => {
-    if (open) toggle();
+    if (open) {
+      toggle();
+    }
     else {
       closeOther();
       toggle();


### PR DESCRIPTION
This pull request makes a minor update to the translation help message in the `TranslateDropdown` component to clarify that translation may be unavailable in addition to being slow to load.