### PR TITLE
Enhance border-radius styling for spectrum segments to improve visual consistency

### DIFF
--- a/frontend/styles/biasAnalysis.css
+++ b/frontend/styles/biasAnalysis.css
@@ -105,6 +105,7 @@
   transition: opacity 0.3s ease;
   z-index: 0;
   pointer-events: none;
+  border-radius: inherit;
 }
 
 .spectrum-segment:first-child {
@@ -112,6 +113,14 @@
 }
 
 .spectrum-segment:last-child {
+  border-radius: 0 22px 22px 0;
+}
+
+.spectrum-segment:first-child::after {
+  border-radius: 22px 0 0 22px;
+}
+
+.spectrum-segment:last-child::after {
   border-radius: 0 22px 22px 0;
 }
 


### PR DESCRIPTION
This pull request makes small but important improvements to the styling of segmented controls in the `biasAnalysis.css` file. The main focus is on ensuring that border radii are consistently applied, especially to the first and last segments, for a more polished visual appearance.

Styling enhancements for segmented controls:

* Added `border-radius: inherit;` to the base segment styling to ensure that segments inherit the correct border radius from their parent container.
* Explicitly set border radii for the `::after` pseudo-elements of the first and last segments to maintain consistent rounded corners at the ends of the segmented control.