### PR TITLE
Increase button size for related articles navigation on mobile and remove unnecessary font size adjustments for article carousel

### DIFF
--- a/frontend/styles/carousel.css
+++ b/frontend/styles/carousel.css
@@ -94,11 +94,6 @@
 
 /* Mobile */
 @media (max-width: 640px) {
-  .article-carousel-section .slick-prev:before,
-  .article-carousel-section .slick-next:before {
-    font-size: 18px !important;
-  }
-
   .article-carousel-section .slick-dots {
     bottom: -35px !important;
   }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -148,8 +148,8 @@ main {
 @media (max-width: 768px) {
   .related-articles-section .slick-prev,
   .related-articles-section .slick-next {
-    width: 40px !important;
-    height: 40px !important;
+    width: 48px !important;
+    height: 48px !important;
     background: transparent !important;
   }
 


### PR DESCRIPTION
This pull request makes minor adjustments to the carousel navigation styling for mobile and tablet breakpoints. The main changes involve updating the size of navigation buttons in the related articles section and removing font size overrides for carousel arrows on mobile.

Styling updates for carousel navigation:

* Increased the width and height of `.slick-prev` and `.slick-next` buttons in the `.related-articles-section` from 40px to 48px for screens up to 768px in `frontend/styles/globals.css`.
* Removed the font size override for `.slick-prev:before` and `.slick-next:before` in `.article-carousel-section` for screens up to 640px in `frontend/styles/carousel.css`.