### PR TITLE
Update README for Google AI API key setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 AICC_API_URL="https://ai-content-curator-backend.vercel.app/"
 AI_INSTRUCTIONS="Summarize the articles concisely and naturally"
 CRAWL_URLS="https://www.whitehouse.gov/briefing-room/,https://www.congress.gov/,https://www.state.gov/press-releases/,https://www.bbc.com/news,https://www.nytimes.com/"
-GOOGLE_AI_API_KEY=
+GOOGLE_AI_API_KEY=dummy
 GOOGLE_AI_API_KEY1=
 GOOGLE_AI_API_KEY2=
 GOOGLE_AI_API_KEY3=

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ As soon as you receive a task (verbally or in writing) or come up with an idea:
 6. Once the task is complete, push the branch to the remote repository and create a pull request (PR) in GitHub.
    - Name the PR with a descriptive title that includes the Jira issue key (e.g., `feat(ui): implement new feature [AICC-123`).
    - Before you commit your changes, make sure to run any applicable tests and ensure that the code is properly formatted and linted.
+   - **Note**: If your changes do not involve any AI functionalities (e.g. chatbot, crawler), then set `GOOGLE_AI_API_KEY=dummy` in your `backend/.env` file to bypass the git hooks that check for AI-related environment variables. This will allow you to commit and push your changes without needing access to the actual API keys, while still maintaining the integrity of the development workflow.
 7. Assign the PR to the appropriate team member for code review.
    - Move the Jira task to the **Code Review** column.
 8. Make any necessary changes based on feedback from the code review.
@@ -1323,6 +1324,9 @@ npm run test:watch
 # Generate a coverage report
 npm run test:coverage
 ```
+
+> [!NOTE]
+> If your changes do not involve AI functionality, you'll need to set `GOOGLE_AI_API_KEY=dummy` in `backend/.env` to prevent tests from failing due to missing API keys.
 
 ### Frontend
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 AICC_API_URL="https://ai-content-curator-backend.vercel.app/"
 AI_INSTRUCTIONS="Summarize the articles concisely and naturally"
 CRAWL_URLS="https://www.whitehouse.gov/briefing-room/,https://www.congress.gov/,https://www.state.gov/press-releases/,https://www.bbc.com/news,https://www.nytimes.com/"
-GOOGLE_AI_API_KEY=
+GOOGLE_AI_API_KEY=dummy
 GOOGLE_AI_API_KEY1=
 GOOGLE_AI_API_KEY2=
 GOOGLE_AI_API_KEY3=

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testTimeout: 60000,
+  setupFiles: ["<rootDir>/src/__tests__/jest.setup.js"],
   moduleFileExtensions: ["ts", "js", "json"],
   testMatch: [
     "**/__tests__/**/*.spec.ts",

--- a/backend/src/__tests__/jest.setup.js
+++ b/backend/src/__tests__/jest.setup.js
@@ -1,0 +1,10 @@
+const googleAiKeys = [
+  process.env.GOOGLE_AI_API_KEY,
+  process.env.GOOGLE_AI_API_KEY1,
+  process.env.GOOGLE_AI_API_KEY2,
+  process.env.GOOGLE_AI_API_KEY3,
+].filter(Boolean);
+
+if (!googleAiKeys.length) {
+  process.env.GOOGLE_AI_API_KEY = "dummy";
+}


### PR DESCRIPTION
This pull request improves the developer experience and reliability of the backend testing workflow by ensuring that missing Google AI API keys do not block non-AI development or testing. It introduces a default dummy API key, updates documentation to clarify this behavior, and configures Jest to automatically set the dummy key if needed.

**Testing and environment variable handling:**

* Added a Jest setup file (`backend/src/__tests__/jest.setup.js`) that automatically sets `GOOGLE_AI_API_KEY` to `"dummy"` if no Google AI API keys are present, preventing test failures due to missing keys.
* Updated `backend/jest.config.js` to include the new setup file, ensuring the dummy key logic runs before tests.

**Environment configuration:**

* Set a default value of `"dummy"` for `GOOGLE_AI_API_KEY` in both `.env.example` and `backend/.env.example` to help developers bypass AI key checks during non-AI development. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL4-R4) [[2]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080L4-R4)

**Documentation updates:**

* Updated the workflow section in `README.md` to instruct developers to set `GOOGLE_AI_API_KEY=dummy` for non-AI changes, clarifying how to bypass git hooks that check for AI-related environment variables.
* Added a note to the backend testing section in `README.md` explaining the need to set the dummy API key when running tests unrelated to AI functionality.