### PR TITLE
feat(auth): add passkey (WebAuthn) support for signup and login

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "mcp__playwright__browser_take_screenshot",
       "Bash(xargs grep:*)",
       "Bash(grep -r agentic /c/Users/nguyens6/AI-Gov-Content-Curator/backend --include=*.ts --include=*.js)",
-      "Bash(grep -r orchestration /c/Users/nguyens6/AI-Gov-Content-Curator --include=*.ts --include=*.py)"
+      "Bash(grep -r orchestration /c/Users/nguyens6/AI-Gov-Content-Curator --include=*.ts --include=*.py)",
+      "Bash(grep -E \"\\\\.\\(ts|tsx|js|jsx\\)$\")"
     ],
     "deny": [],
     "ask": []

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1650,20 +1650,33 @@ graph TB
 
 **JWT-Based Authentication:**
 - **Algorithm:** HS256 (HMAC with SHA-256)
-- **Token expiry:** 24 hours
-- **Refresh tokens:** 7 days
-- **Middleware:** `auth.middleware.ts`
+- **Token expiry:** 72 hours
+- **Middleware:** `auth.middleware.ts` — reads raw token from `Authorization` header (no `Bearer` prefix)
+- **Issuance helper:** `services/auth-token.service.ts` (`signJwt(user)`) — single source of truth used by both password login and passkey verification.
+
+**Two sign-in paths, one token:**
+1. **Email + password** — `/api/auth/register` → `/api/auth/login`. Bcrypt-hashed password.
+2. **Passkey (WebAuthn / FIDO2)** — `/api/auth/passkey/*`. Uses `@simplewebauthn/server` v11. Discoverable / usernameless authentication via resident credentials. Passkeys may be added to a passworded account, or a brand-new account may be created passkey-only (`/api/auth/passkey/signup/*`).
+
+Both paths issue an identical JWT. The `User.password` field is **optional**; a Mongoose pre-save validator enforces that every account has at least one credential (password or `hasPasskeys=true`). Account recovery for passkey-only users is the existing `/api/auth/reset-password` flow, which doubles as "set initial password".
+
+**RP ID:** must equal the **frontend** apex domain (`synthoraai.vercel.app` in prod, `localhost` in dev) because the browser binds credentials to the origin running `navigator.credentials.create/get`. Configured via `RP_ID`, `RP_NAME`, `RP_ORIGIN` env vars.
+
+**Challenge state:** stored in a `WebAuthnChallenge` Mongo collection with a TTL index on `expiresAt` (5-minute expiry) and a unique index on `challenge`. Rows are deleted on successful verify, preventing replay within the TTL window.
 
 **Protected Routes:**
 - Comments CRUD
 - Favorites management
 - Ratings submission
 - User profile updates
+- Passkey CRUD (`GET /api/auth/passkey`, `PATCH /api/auth/passkey/:id`, `DELETE /api/auth/passkey/:id`)
+- Passkey registration begin/verify (adding a passkey to an existing account)
 
 **Public Routes:**
 - Article list/detail
 - AI chat (rate-limited)
 - Health checks
+- All passkey signup and authentication endpoints (the WebAuthn ceremony itself is the credential)
 
 ### Secrets Management
 
@@ -1863,6 +1876,9 @@ aws cloudwatch get-metric-statistics \
 | `RESEND_API_KEY` | Yes (newsletter) | Email delivery API key | `re_...` |
 | `NEWS_API_KEY` | Yes (crawler) | News API key | `...` |
 | `JWT_SECRET` | Yes (backend) | JWT signing secret | `random-256-bit-string` |
+| `RP_ID` | Yes (backend) | WebAuthn Relying Party ID — **frontend** apex domain (eTLD+1) | `synthoraai.vercel.app` / `localhost` |
+| `RP_NAME` | Yes (backend) | Human-readable RP name shown in browser passkey prompts | `SynthoraAI` |
+| `RP_ORIGIN` | Yes (backend) | Comma-separated allowlist of accepted frontend origins | `https://synthoraai.vercel.app,http://localhost:3000` |
 | `REDIS_URL` | No | Redis connection URL | `redis://...` |
 
 **Frontend:**
@@ -1923,12 +1939,49 @@ aws cloudwatch get-metric-statistics \
 {
   _id: ObjectId,
   email: string (unique),
-  passwordHash: string,
-  role: 'user' | 'admin',
-  favorites: ObjectId[] (article refs),
+  password?: string,                  // bcrypt hash; OPTIONAL — passkey-only accounts have none
+  name?: string,
+  isVerified: boolean,
+  verificationToken?: string,
+  resetPasswordToken?: string,
+  hasPasskeys?: boolean,              // denormalized flag, maintained on register/delete passkey
+  favorites: string[],                // article IDs
   createdAt: Date,
-  lastLogin: Date
+  updatedAt: Date,
 }
+// Pre-save validator: every user must have at least one of `password` or `hasPasskeys=true`.
+```
+
+**Passkeys (`passkey.model.ts`):**
+```typescript
+{
+  _id: ObjectId,
+  userId: ObjectId,                   // ref User; indexed
+  credentialId: string,                // base64url, UNIQUE indexed — primary lookup at auth time
+  publicKey: Buffer,                   // COSE public key from authenticator
+  counter: number,
+  transports?: AuthenticatorTransport[],
+  deviceType: 'singleDevice' | 'multiDevice',
+  backedUp: boolean,
+  nickname: string,                    // user-editable, e.g. "iPhone 15"
+  aaguid?: string,
+  lastUsedAt?: Date,
+  createdAt: Date,
+  updatedAt: Date,
+}
+```
+
+**WebAuthn Challenges (`webauthn-challenge.model.ts`):**
+```typescript
+{
+  _id: ObjectId,
+  challenge: string,                   // base64url, UNIQUE indexed
+  type: 'registration' | 'authentication',
+  userId?: ObjectId,                   // present for adding-a-passkey-to-existing-account
+  email?: string,                      // present for passkey-only signup (no User row yet)
+  expiresAt: Date,                     // TTL index, expireAfterSeconds: 0 (5-min lifetime)
+}
+// Rows are deleted on successful verify to prevent replay within the TTL window.
 ```
 
 **Comments (`comment.model.ts`):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This repository is a monorepo for an AI-assisted government article curation platform.
 The main services are:
 
-- `backend/`: Express + TypeScript API, MongoDB, JWT auth, Gemini, Pinecone.
+- `backend/`: Express + TypeScript API, MongoDB, JWT auth (email+password and WebAuthn passkeys via `@simplewebauthn/server`), Gemini, Pinecone.
 - `frontend/`: Next.js Pages Router app for article browsing, auth UX, comments, ratings, and chat.
 - `crawler/`: scheduled ingestion pipeline using Axios/Cheerio/Puppeteer, Gemini, MongoDB, Pinecone.
 - `newsletters/`: scheduled Resend-based digest sender backed by MongoDB.
@@ -21,7 +21,7 @@ The main services are:
 - Prefer the root `package.json` scripts, workspace `package.json` scripts, and `bin/aicc.js` over older `shell/` wrappers when both exist.
 - Treat README files as helpful but not fully authoritative. Check current code, `package.json`, `vercel.json`, Dockerfiles, and actual routes before making assumptions.
 - Be careful with live-side effects. The crawler can hit external sites and APIs. The newsletter job can send email and mutate subscriber state. Cleanup scripts delete or rewrite records.
-- Security-sensitive areas need extra review: `backend/src/controllers/auth.controller.ts`, auth middleware, password reset flows, newsletter unsubscribe logic, and infra secrets.
+- Security-sensitive areas need extra review: `backend/src/controllers/auth.controller.ts`, `backend/src/controllers/passkey.controller.ts`, `backend/src/services/auth-token.service.ts` (shared JWT issuance), `backend/src/services/webauthn.service.ts` (RP config), auth middleware, password reset flows, newsletter unsubscribe logic, and infra secrets.
 
 ## Canonical Commands
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The **Backend** is responsible for storing articles and serving them via RESTful
 - **Scheduled Updates:**  
   A serverless function (triggered twice daily at 6:00 AM and 6:00 PM UTC) fetches and processes new articles, so that the system remains up-to-date!
 - **User Authentication:**  
-  Supports user registration, login, and JWT-based authentication for secure access to the system.
+  Supports email + password registration, login, and JWT-based authentication, **plus passwordless passkey (WebAuthn / FIDO2) sign-in**. Users can sign up with a passkey only, add additional passkeys to an existing account, and manage them (list / rename / delete) at `/account/passkeys`. Both flows issue the same JWT, so the rest of the system is unchanged.
 - **Favorite Articles:**  
   Authenticated users can mark articles as favorites for quick access.
 - **Newsletter Subscription:**  
@@ -493,6 +493,15 @@ AICC_API_URL=https://ai-content-curator-backend.vercel.app/
 RESEND_API_KEY=<your_resend_api_key>
 RESEND_FROM="AI Curator <your_email>"
 UNSUBSCRIBE_BASE_URL=<your_unsubscribe_base_url>
+
+# Auth
+JWT_SECRET=<long_random_string>
+
+# WebAuthn / Passkey configuration
+# RP_ID MUST equal the FRONTEND apex domain (eTLD+1), not the backend's host.
+RP_ID=localhost
+RP_NAME=SynthoraAI
+RP_ORIGIN=http://localhost:3000,https://synthoraai.vercel.app
 ```
 
 Refer to the `.env.example` file for more details on each variable.
@@ -669,7 +678,7 @@ The **Frontend** is built with Next.js and React, providing a modern, mobile-res
   The UI is optimized for both desktop and mobile devices.
 
 - **Authentication:**  
-  Users can register, log in, and receive a JWT token for secure access to the system. Tokens are stored in HTTP-only cookies for security.
+  Users can register and log in with email + password, or sign in with a **passkey** (Face ID, Touch ID, Windows Hello, or a hardware key) for a faster, passwordless experience. New accounts may be created passkey-only. The frontend stores the issued JWT in `localStorage` and sends it on the `Authorization` header for protected routes.
 
 - **Chatbot Q&A Feature:**
   Users can ask questions about specific articles, powered by RAG (Retrieval-Augmented Generation) using Google Generative AI. The sitewide chat supports inline message editing with conversation branching—edit any prior message and the conversation forks from that point with fresh AI responses.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,3 +20,11 @@ RESEND_FROM="AI Curator <news@sonnguyenhoang.com>"
 UNSUBSCRIBE_BASE_URL="https://ai-content-curator-backend.vercel.app/api/newsletter/unsubscribe"
 PINECONE_API_KEY=
 PINECONE_INDEX=ai-gov-articles
+
+# WebAuthn / Passkey configuration
+# RP_ID must equal the FRONTEND apex domain (eTLD+1). Production uses
+# `synthoraai.vercel.app`; local dev uses `localhost`.
+RP_ID=localhost
+RP_NAME=SynthoraAI
+# Comma-separated allowlist of full origins that the frontend will be served from.
+RP_ORIGIN=http://localhost:3000,https://synthoraai.vercel.app

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -11,7 +11,10 @@ Work here when the task touches API routes, controllers, models, auth, scheduled
 
 ## Guardrails
 
-- Do not weaken auth or reset-password flows without explicit justification.
+- Do not weaken auth, passkey, or reset-password flows without explicit justification. Both password and passkey paths funnel through `services/auth-token.service.ts` for JWT issuance — don't reintroduce inline `jwt.sign` in controllers.
+- The `User.password` field is OPTIONAL (passkey-only accounts have no password). A pre-save validator requires every user to have at least `password` or `hasPasskeys=true`. Don't remove this validator.
+- WebAuthn challenge state lives in the `WebAuthnChallenge` collection with a Mongo TTL index. Don't add ad-hoc challenge storage.
+- `RP_ID` MUST equal the frontend apex domain, not the backend's host.
 - Preserve API shapes unless the frontend is updated in the same change.
 - Prefer schema and controller fixes over ad hoc response reshaping in random files.
 - Be aware that build and deploy assumptions are inconsistent here. Check Docker, TypeScript output, and Vercel handlers together when touching runtime wiring.

--- a/backend/README.md
+++ b/backend/README.md
@@ -99,10 +99,24 @@ flowchart LR
 - **Express.js API Endpoints:**  
   The backend provides the following RESTful endpoints (running within a Next.js environment):
 
-  | **Method** | **Endpoint**        | **Description**                                                                       |
-  | ---------- | ------------------- | ------------------------------------------------------------------------------------- |
-  | GET        | `/api/articles`     | Returns a paginated list of articles. Accepts `page`, `limit`, `source` query params. |
-  | GET        | `/api/articles/:id` | Retrieves detailed information about a single article by its ID.                      |
+  | **Method** | **Endpoint**                              | **Auth** | **Description**                                                                       |
+  | ---------- | ----------------------------------------- | -------- | ------------------------------------------------------------------------------------- |
+  | GET        | `/api/articles`                           | —        | Returns a paginated list of articles. Accepts `page`, `limit`, `source` query params. |
+  | GET        | `/api/articles/:id`                       | —        | Retrieves detailed information about a single article by its ID.                      |
+  | POST       | `/api/auth/register`                      | —        | Email + password signup. Returns user + JWT.                                          |
+  | POST       | `/api/auth/login`                         | —        | Email + password login. Returns user + JWT.                                           |
+  | GET        | `/api/auth/verify-email`                  | —        | Email verification via token (`?email&token`).                                        |
+  | POST       | `/api/auth/reset-password`                | —        | Request a password-reset token.                                                       |
+  | POST       | `/api/auth/confirm-reset-password`        | —        | Confirm reset and set a new password (also doubles as "set initial password" for passkey-only accounts). |
+  | POST       | `/api/auth/passkey/signup/begin`          | —        | Start passkey-only signup (no User row created yet).                                  |
+  | POST       | `/api/auth/passkey/signup/verify`         | —        | Finish passkey signup. Creates User + Passkey atomically and issues JWT.              |
+  | POST       | `/api/auth/passkey/authenticate/begin`    | —        | Begin discoverable / usernameless passkey login.                                      |
+  | POST       | `/api/auth/passkey/authenticate/verify`   | —        | Finish passkey login. Returns user + JWT identical to password login.                 |
+  | POST       | `/api/auth/passkey/register/begin`        | JWT      | Begin adding a passkey to the current account.                                        |
+  | POST       | `/api/auth/passkey/register/verify`       | JWT      | Persist a newly registered passkey.                                                   |
+  | GET        | `/api/auth/passkey`                       | JWT      | List the caller's passkeys.                                                           |
+  | PATCH      | `/api/auth/passkey/:id`                   | JWT      | Rename a passkey.                                                                     |
+  | DELETE     | `/api/auth/passkey/:id`                   | JWT      | Delete a passkey (refuses if it would orphan a passwordless account).                 |
 
 ### Request Lifecycle
 
@@ -179,6 +193,19 @@ sequenceDiagram
    NEWS_API_KEY=your_newsapi_key
    PORT=3000
    CRAWL_URLS=https://www.whitehouse.gov/briefing-room/,https://www.congress.gov/,https://www.state.gov/press-releases/,https://www.bbc.com/news,https://www.nytimes.com/
+
+   # Auth
+   JWT_SECRET=replace_with_a_long_random_string
+
+   # WebAuthn / Passkey configuration
+   # RP_ID MUST equal the FRONTEND apex domain (eTLD+1), not the backend's host.
+   # Production: synthoraai.vercel.app — vercel.app is on the Public Suffix
+   # List, so the subdomain itself is the registrable domain.
+   # Local dev: localhost.
+   RP_ID=localhost
+   RP_NAME=SynthoraAI
+   # Comma-separated allowlist of full origins the frontend will be served from.
+   RP_ORIGIN=http://localhost:3000,https://synthoraai.vercel.app
    ```
 
 ### Run Locally

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "@pinecone-database/pinecone": "^6.1.2",
+    "@simplewebauthn/server": "^11.0.0",
     "@vercel/node": "^5.1.10",
     "axios": "^1.2.0",
     "bcrypt": "^5.1.1",

--- a/backend/src/__tests__/passkey.controller.spec.js
+++ b/backend/src/__tests__/passkey.controller.spec.js
@@ -1,0 +1,453 @@
+// Mock User model
+jest.mock("../models/user.model", () => {
+  const User = jest.fn(function (doc) {
+    Object.assign(this, doc);
+    this._id = this._id || "u1";
+    this.save = jest.fn().mockResolvedValue(this);
+  });
+  User.findOne = jest.fn();
+  User.findById = jest.fn();
+  return User;
+});
+
+// Mock Passkey model
+jest.mock("../models/passkey.model", () => {
+  const Passkey = jest.fn();
+  Passkey.find = jest.fn();
+  Passkey.findOne = jest.fn();
+  Passkey.findById = jest.fn();
+  Passkey.create = jest.fn();
+  Passkey.countDocuments = jest.fn();
+  return Passkey;
+});
+
+// Mock WebAuthnChallenge model
+jest.mock("../models/webauthn-challenge.model", () => {
+  const Challenge = jest.fn();
+  Challenge.create = jest.fn();
+  Challenge.findOne = jest.fn();
+  return Challenge;
+});
+
+// Mock the webauthn service
+jest.mock("../services/webauthn.service", () => ({
+  RP_ID: "localhost",
+  RP_NAME: "Test",
+  RP_ORIGINS: ["http://localhost:3000"],
+  CHALLENGE_TTL_MS: 5 * 60 * 1000,
+  generateRegistrationOptions: jest
+    .fn()
+    .mockResolvedValue({ challenge: "ch-reg" }),
+  verifyRegistrationResponse: jest.fn(),
+  generateAuthenticationOptions: jest
+    .fn()
+    .mockResolvedValue({ challenge: "ch-auth" }),
+  verifyAuthenticationResponse: jest.fn(),
+}));
+
+jest.mock("../services/auth-token.service", () => ({
+  signJwt: jest.fn().mockReturnValue("jwt-token"),
+}));
+
+const User = require("../models/user.model");
+const Passkey = require("../models/passkey.model");
+const Challenge = require("../models/webauthn-challenge.model");
+const webauthn = require("../services/webauthn.service");
+
+const {
+  beginRegistration,
+  verifyRegistration,
+  beginAuthentication,
+  verifyAuthentication,
+  beginSignup,
+  verifySignup,
+  listPasskeys,
+  renamePasskey,
+  deletePasskey,
+} = require("../controllers/passkey.controller");
+
+const mockReq = ({ body = {}, params = {}, query = {}, user } = {}) => ({
+  body,
+  params,
+  query,
+  user,
+});
+
+const mockRes = () => {
+  const r = {};
+  r.status = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  r.setHeader = jest.fn();
+  return r;
+};
+
+const buildClientDataJSON = (challenge) =>
+  Buffer.from(JSON.stringify({ challenge }), "utf8").toString("base64");
+
+describe("Passkey Controller", () => {
+  let res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.error = jest.fn();
+    res = mockRes();
+  });
+
+  describe("beginRegistration()", () => {
+    it("401 when unauthenticated", async () => {
+      await beginRegistration(mockReq({}), res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("404 when user missing", async () => {
+      User.findById.mockResolvedValue(null);
+      await beginRegistration(
+        mockReq({ user: { id: "u1", email: "a@b.com" } }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("returns options and persists challenge", async () => {
+      User.findById.mockResolvedValue({
+        _id: "u1",
+        email: "a@b.com",
+        name: "N",
+      });
+      Passkey.find.mockResolvedValue([]);
+      Challenge.create.mockResolvedValue({});
+      await beginRegistration(
+        mockReq({ user: { id: "u1", email: "a@b.com" } }),
+        res,
+      );
+      expect(webauthn.generateRegistrationOptions).toHaveBeenCalled();
+      expect(Challenge.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          challenge: "ch-reg",
+          type: "registration",
+          userId: "u1",
+        }),
+      );
+      expect(res.json).toHaveBeenCalledWith({ challenge: "ch-reg" });
+    });
+  });
+
+  describe("verifyRegistration()", () => {
+    it("400 when challenge not found", async () => {
+      Challenge.findOne.mockResolvedValue(null);
+      await verifyRegistration(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          body: {
+            response: {
+              response: { clientDataJSON: buildClientDataJSON("ch-reg") },
+            },
+          },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("400 when challenge expired", async () => {
+      Challenge.findOne.mockResolvedValue({
+        expiresAt: new Date(Date.now() - 1000),
+        deleteOne: jest.fn(),
+      });
+      await verifyRegistration(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          body: {
+            response: {
+              response: { clientDataJSON: buildClientDataJSON("ch-reg") },
+            },
+          },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("201 on successful verification", async () => {
+      Challenge.findOne.mockResolvedValue({
+        expiresAt: new Date(Date.now() + 60_000),
+        deleteOne: jest.fn(),
+      });
+      webauthn.verifyRegistrationResponse.mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: "cred-id",
+            publicKey: new Uint8Array([1, 2, 3]),
+            counter: 0,
+          },
+          credentialDeviceType: "multiDevice",
+          credentialBackedUp: true,
+        },
+      });
+      User.findById.mockResolvedValue({
+        _id: "u1",
+        email: "a@b.com",
+        save: jest.fn().mockResolvedValue(true),
+      });
+      Passkey.create.mockResolvedValue({
+        _id: "pk1",
+        nickname: "Test",
+        createdAt: new Date(),
+        deviceType: "multiDevice",
+        backedUp: true,
+      });
+
+      await verifyRegistration(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          body: {
+            response: {
+              response: { clientDataJSON: buildClientDataJSON("ch-reg") },
+            },
+            nickname: "Test",
+          },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(Passkey.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("beginAuthentication()", () => {
+    it("returns options and persists challenge", async () => {
+      Challenge.create.mockResolvedValue({});
+      await beginAuthentication(mockReq({}), res);
+      expect(webauthn.generateAuthenticationOptions).toHaveBeenCalled();
+      expect(Challenge.create).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({ challenge: "ch-auth" });
+    });
+  });
+
+  describe("verifyAuthentication()", () => {
+    it("400 when credential unknown", async () => {
+      Challenge.findOne.mockResolvedValue({
+        expiresAt: new Date(Date.now() + 60_000),
+        deleteOne: jest.fn(),
+      });
+      Passkey.findOne.mockResolvedValue(null);
+      await verifyAuthentication(
+        mockReq({
+          body: {
+            response: {
+              id: "cred-id",
+              response: { clientDataJSON: buildClientDataJSON("ch-auth") },
+            },
+          },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("issues JWT on successful verification", async () => {
+      Challenge.findOne.mockResolvedValue({
+        expiresAt: new Date(Date.now() + 60_000),
+        deleteOne: jest.fn(),
+      });
+      Passkey.findOne.mockResolvedValue({
+        credentialId: "cred-id",
+        publicKey: Buffer.from([1, 2, 3]),
+        counter: 0,
+        transports: ["internal"],
+        userId: "u1",
+        save: jest.fn().mockResolvedValue(true),
+      });
+      webauthn.verifyAuthenticationResponse.mockResolvedValue({
+        verified: true,
+        authenticationInfo: { newCounter: 1 },
+      });
+      User.findById.mockResolvedValue({
+        _id: "u1",
+        email: "a@b.com",
+        name: "N",
+        isVerified: true,
+      });
+      await verifyAuthentication(
+        mockReq({
+          body: {
+            response: {
+              id: "cred-id",
+              response: { clientDataJSON: buildClientDataJSON("ch-auth") },
+            },
+          },
+        }),
+        res,
+      );
+      expect(res.setHeader).toHaveBeenCalledWith("Authorization", "jwt-token");
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ token: "jwt-token" }),
+      );
+    });
+  });
+
+  describe("beginSignup()", () => {
+    it("400 when email missing", async () => {
+      await beginSignup(mockReq({ body: {} }), res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("400 when user already exists", async () => {
+      User.findOne.mockResolvedValue({ _id: "exists" });
+      await beginSignup(mockReq({ body: { email: "a@b.com" } }), res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("returns options without creating a user", async () => {
+      User.findOne.mockResolvedValue(null);
+      Challenge.create.mockResolvedValue({});
+      await beginSignup(
+        mockReq({ body: { email: "a@b.com", name: "N" } }),
+        res,
+      );
+      // User constructor must NOT be invoked at begin time — user is created on verify.
+      expect(User).not.toHaveBeenCalled();
+      expect(webauthn.generateRegistrationOptions).toHaveBeenCalled();
+      expect(Challenge.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          challenge: "ch-reg",
+          type: "registration",
+          email: "a@b.com",
+        }),
+      );
+      expect(res.json).toHaveBeenCalledWith({ challenge: "ch-reg" });
+    });
+  });
+
+  describe("listPasskeys()", () => {
+    it("401 when unauthenticated", async () => {
+      await listPasskeys(mockReq({}), res);
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it("returns shaped passkeys", async () => {
+      Passkey.find.mockReturnValue({
+        sort: jest.fn().mockResolvedValue([
+          {
+            _id: "pk1",
+            nickname: "iPhone",
+            createdAt: new Date(),
+            lastUsedAt: null,
+            deviceType: "multiDevice",
+            backedUp: true,
+          },
+        ]),
+      });
+      await listPasskeys(
+        mockReq({ user: { id: "u1", email: "a@b.com" } }),
+        res,
+      );
+      expect(res.json).toHaveBeenCalled();
+      const out = res.json.mock.calls[0][0];
+      expect(Array.isArray(out)).toBe(true);
+      expect(out[0]).toEqual(
+        expect.objectContaining({ id: "pk1", nickname: "iPhone" }),
+      );
+    });
+  });
+
+  describe("renamePasskey()", () => {
+    it("400 when nickname missing", async () => {
+      await renamePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+          body: {},
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("404 when passkey not found", async () => {
+      Passkey.findOne.mockResolvedValue(null);
+      await renamePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+          body: { nickname: "X" },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("renames", async () => {
+      Passkey.findOne.mockResolvedValue({
+        _id: "pk1",
+        nickname: "Old",
+        save: jest.fn().mockResolvedValue(true),
+      });
+      await renamePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+          body: { nickname: "New" },
+        }),
+        res,
+      );
+      expect(res.json).toHaveBeenCalledWith({ id: "pk1", nickname: "New" });
+    });
+  });
+
+  describe("deletePasskey()", () => {
+    it("404 when passkey not found", async () => {
+      Passkey.findOne.mockResolvedValue(null);
+      await deletePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("400 when deleting last passkey on passwordless account", async () => {
+      Passkey.findOne.mockResolvedValue({
+        _id: "pk1",
+        deleteOne: jest.fn(),
+      });
+      User.findById.mockResolvedValue({
+        _id: "u1",
+        password: undefined,
+        save: jest.fn(),
+      });
+      Passkey.countDocuments.mockResolvedValue(1);
+      await deletePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("deletes successfully when password exists", async () => {
+      const passkey = { _id: "pk1", deleteOne: jest.fn() };
+      Passkey.findOne.mockResolvedValue(passkey);
+      User.findById.mockResolvedValue({
+        _id: "u1",
+        password: "hashed",
+        save: jest.fn().mockResolvedValue(true),
+      });
+      Passkey.countDocuments.mockResolvedValue(2);
+      await deletePasskey(
+        mockReq({
+          user: { id: "u1", email: "a@b.com" },
+          params: { id: "pk1" },
+        }),
+        res,
+      );
+      expect(passkey.deleteOne).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+    });
+  });
+});

--- a/backend/src/__tests__/passkey.model.spec.js
+++ b/backend/src/__tests__/passkey.model.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Real-Mongo integration test for the User / Passkey / WebAuthnChallenge
+ * schemas. Exercises validators, indexes, and TTL configuration with
+ * mongodb-memory-server.
+ */
+const mongoose = require("mongoose");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+
+let mongoServer;
+let User, Passkey, Challenge;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  // Lazy-load AFTER mongoose connect so models register on the same connection.
+  User = require("../models/user.model").default;
+  Passkey = require("../models/passkey.model").default;
+  Challenge = require("../models/webauthn-challenge.model").default;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await User.deleteMany({});
+  await Passkey.deleteMany({});
+  await Challenge.deleteMany({});
+});
+
+describe("User model", () => {
+  it("requires at least one of password / hasPasskeys", async () => {
+    const u = new User({ email: "a@b.com", isVerified: false, favorites: [] });
+    await expect(u.save()).rejects.toThrow(/at least one credential/);
+  });
+
+  it("accepts a password-only user", async () => {
+    const u = new User({
+      email: "a@b.com",
+      password: "hashed",
+      isVerified: false,
+      favorites: [],
+    });
+    await expect(u.save()).resolves.toBeDefined();
+  });
+
+  it("accepts a passkey-only user (no password)", async () => {
+    const u = new User({
+      email: "a@b.com",
+      hasPasskeys: true,
+      isVerified: false,
+      favorites: [],
+    });
+    const saved = await u.save();
+    expect(saved.password).toBeUndefined();
+    expect(saved.hasPasskeys).toBe(true);
+  });
+});
+
+describe("Passkey model", () => {
+  let user;
+  beforeEach(async () => {
+    user = await User.create({
+      email: "a@b.com",
+      hasPasskeys: true,
+      favorites: [],
+    });
+  });
+
+  it("enforces uniqueness of credentialId", async () => {
+    await Passkey.init(); // ensure indexes are built
+    await Passkey.create({
+      userId: user._id,
+      credentialId: "cred-1",
+      publicKey: Buffer.from([1, 2, 3]),
+      counter: 0,
+      nickname: "A",
+    });
+    await expect(
+      Passkey.create({
+        userId: user._id,
+        credentialId: "cred-1",
+        publicKey: Buffer.from([4, 5, 6]),
+        counter: 0,
+        nickname: "B",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("supports multiple passkeys per user", async () => {
+    await Passkey.create([
+      {
+        userId: user._id,
+        credentialId: "cred-a",
+        publicKey: Buffer.from([1]),
+        counter: 0,
+        nickname: "A",
+      },
+      {
+        userId: user._id,
+        credentialId: "cred-b",
+        publicKey: Buffer.from([2]),
+        counter: 0,
+        nickname: "B",
+      },
+    ]);
+    const list = await Passkey.find({ userId: user._id });
+    expect(list).toHaveLength(2);
+  });
+
+  it("preserves publicKey bytes round-trip", async () => {
+    const bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const created = await Passkey.create({
+      userId: user._id,
+      credentialId: "cred-bytes",
+      publicKey: bytes,
+      counter: 5,
+      nickname: "Bytes",
+    });
+    const fetched = await Passkey.findById(created._id);
+    expect(Buffer.from(fetched.publicKey).equals(bytes)).toBe(true);
+    expect(fetched.counter).toBe(5);
+  });
+});
+
+describe("WebAuthnChallenge model", () => {
+  it("enforces uniqueness of challenge", async () => {
+    await Challenge.init();
+    await Challenge.create({
+      challenge: "abc",
+      type: "registration",
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    await expect(
+      Challenge.create({
+        challenge: "abc",
+        type: "authentication",
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("declares a TTL index on expiresAt", async () => {
+    await Challenge.init();
+    const indexes = await Challenge.collection.indexes();
+    const ttl = indexes.find(
+      (i) => i.key && i.key.expiresAt === 1 && i.expireAfterSeconds === 0,
+    );
+    expect(ttl).toBeDefined();
+  });
+});

--- a/backend/src/__tests__/passkey.routes.spec.js
+++ b/backend/src/__tests__/passkey.routes.spec.js
@@ -1,0 +1,295 @@
+/**
+ * Integration test: real Express + real Mongoose + mocked WebAuthn library.
+ * Exercises the full /api/auth/passkey/* route stack to catch wiring bugs
+ * the unit tests can't see.
+ */
+jest.mock("../services/webauthn.service", () => ({
+  RP_ID: "localhost",
+  RP_NAME: "Test",
+  RP_ORIGINS: ["http://localhost:3000"],
+  CHALLENGE_TTL_MS: 5 * 60 * 1000,
+  generateRegistrationOptions: jest.fn(),
+  verifyRegistrationResponse: jest.fn(),
+  generateAuthenticationOptions: jest.fn(),
+  verifyAuthenticationResponse: jest.fn(),
+}));
+
+const express = require("express");
+const mongoose = require("mongoose");
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+
+const webauthn = require("../services/webauthn.service");
+
+let mongoServer;
+let app;
+let User, Passkey;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  User = require("../models/user.model").default;
+  Passkey = require("../models/passkey.model").default;
+  const passkeyRoutes = require("../routes/passkey.routes").default;
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/auth/passkey", passkeyRoutes);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  jest.clearAllMocks();
+  await User.deleteMany({});
+  await Passkey.deleteMany({});
+  const Challenge = require("../models/webauthn-challenge.model").default;
+  await Challenge.deleteMany({});
+});
+
+const authTokenFor = (userId, email) =>
+  jwt.sign({ id: userId, email }, "your_jwt_secret", { expiresIn: "1h" });
+
+const buildClientDataJSON = (challenge) =>
+  Buffer.from(JSON.stringify({ challenge }), "utf8").toString("base64url");
+
+describe("POST /api/auth/passkey/authenticate/begin", () => {
+  it("returns options without auth", async () => {
+    webauthn.generateAuthenticationOptions.mockResolvedValue({
+      challenge: "ch-auth",
+      rpId: "localhost",
+      allowCredentials: [],
+    });
+
+    const res = await request(app)
+      .post("/api/auth/passkey/authenticate/begin")
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.challenge).toBe("ch-auth");
+
+    const Challenge = require("../models/webauthn-challenge.model").default;
+    const stored = await Challenge.findOne({ challenge: "ch-auth" });
+    expect(stored).toBeDefined();
+    expect(stored.type).toBe("authentication");
+  });
+});
+
+describe("POST /api/auth/passkey/register/begin", () => {
+  it("401 without auth header", async () => {
+    const res = await request(app)
+      .post("/api/auth/passkey/register/begin")
+      .send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("returns options for an authenticated user", async () => {
+    const user = await User.create({
+      email: "a@b.com",
+      password: "hashed",
+      favorites: [],
+    });
+    webauthn.generateRegistrationOptions.mockResolvedValue({
+      challenge: "ch-reg",
+    });
+    const token = authTokenFor(String(user._id), user.email);
+
+    const res = await request(app)
+      .post("/api/auth/passkey/register/begin")
+      .set("Authorization", token)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.challenge).toBe("ch-reg");
+  });
+});
+
+describe("Passkey CRUD", () => {
+  it("lists, renames, and deletes the caller's passkeys", async () => {
+    const user = await User.create({
+      email: "a@b.com",
+      password: "hashed",
+      hasPasskeys: true,
+      favorites: [],
+    });
+    const pk = await Passkey.create({
+      userId: user._id,
+      credentialId: "cred-1",
+      publicKey: Buffer.from([1, 2, 3]),
+      counter: 0,
+      nickname: "Old name",
+    });
+    const token = authTokenFor(String(user._id), user.email);
+
+    const list = await request(app)
+      .get("/api/auth/passkey")
+      .set("Authorization", token);
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(1);
+    expect(list.body[0].nickname).toBe("Old name");
+
+    const rename = await request(app)
+      .patch(`/api/auth/passkey/${pk._id}`)
+      .set("Authorization", token)
+      .send({ nickname: "New name" });
+    expect(rename.status).toBe(200);
+    expect(rename.body.nickname).toBe("New name");
+
+    const del = await request(app)
+      .delete(`/api/auth/passkey/${pk._id}`)
+      .set("Authorization", token);
+    // Last passkey on a passworded account is allowed to be deleted.
+    expect(del.status).toBe(200);
+
+    const empty = await request(app)
+      .get("/api/auth/passkey")
+      .set("Authorization", token);
+    expect(empty.body).toHaveLength(0);
+
+    // hasPasskeys flipped back to false
+    const refreshed = await User.findById(user._id);
+    expect(refreshed.hasPasskeys).toBe(false);
+  });
+
+  it("refuses to delete the last passkey when no password is set", async () => {
+    const user = await User.create({
+      email: "a@b.com",
+      hasPasskeys: true,
+      favorites: [],
+    });
+    const pk = await Passkey.create({
+      userId: user._id,
+      credentialId: "cred-only",
+      publicKey: Buffer.from([1, 2, 3]),
+      counter: 0,
+      nickname: "Only",
+    });
+    const token = authTokenFor(String(user._id), user.email);
+
+    const res = await request(app)
+      .delete(`/api/auth/passkey/${pk._id}`)
+      .set("Authorization", token);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/last passkey/i);
+
+    // Passkey is still there.
+    const list = await Passkey.find({ userId: user._id });
+    expect(list).toHaveLength(1);
+  });
+
+  it("a user cannot rename or delete another user's passkey", async () => {
+    const a = await User.create({
+      email: "a@b.com",
+      password: "hashed",
+      hasPasskeys: true,
+      favorites: [],
+    });
+    const b = await User.create({
+      email: "b@b.com",
+      password: "hashed",
+      hasPasskeys: true,
+      favorites: [],
+    });
+    const aPk = await Passkey.create({
+      userId: a._id,
+      credentialId: "cred-a",
+      publicKey: Buffer.from([1]),
+      counter: 0,
+      nickname: "A's",
+    });
+
+    const bToken = authTokenFor(String(b._id), b.email);
+    const rename = await request(app)
+      .patch(`/api/auth/passkey/${aPk._id}`)
+      .set("Authorization", bToken)
+      .send({ nickname: "Hijack" });
+    expect(rename.status).toBe(404);
+
+    const del = await request(app)
+      .delete(`/api/auth/passkey/${aPk._id}`)
+      .set("Authorization", bToken);
+    expect(del.status).toBe(404);
+  });
+});
+
+describe("Passkey signup flow (no orphan user)", () => {
+  it("/signup/begin does NOT create a user — only verify does", async () => {
+    webauthn.generateRegistrationOptions.mockResolvedValue({
+      challenge: "ch-signup",
+    });
+    const res = await request(app)
+      .post("/api/auth/passkey/signup/begin")
+      .send({ email: "new@x.com", name: "New" });
+    expect(res.status).toBe(200);
+
+    const u = await User.findOne({ email: "new@x.com" });
+    expect(u).toBeNull();
+
+    const Challenge = require("../models/webauthn-challenge.model").default;
+    const ch = await Challenge.findOne({ challenge: "ch-signup" });
+    expect(ch.email).toBe("new@x.com");
+    expect(ch.userId).toBeUndefined();
+  });
+
+  it("/signup/begin rejects existing emails", async () => {
+    await User.create({
+      email: "exists@x.com",
+      password: "hashed",
+      favorites: [],
+    });
+    const res = await request(app)
+      .post("/api/auth/passkey/signup/begin")
+      .send({ email: "exists@x.com" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/already exists/i);
+  });
+
+  it("/signup/verify creates user + passkey atomically and issues JWT", async () => {
+    webauthn.generateRegistrationOptions.mockResolvedValue({
+      challenge: "ch-flow",
+    });
+    await request(app)
+      .post("/api/auth/passkey/signup/begin")
+      .send({ email: "atomic@x.com", name: "Atom" });
+
+    webauthn.verifyRegistrationResponse.mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: "cred-atomic",
+          publicKey: new Uint8Array([1, 2, 3]),
+          counter: 0,
+        },
+        credentialDeviceType: "multiDevice",
+        credentialBackedUp: true,
+      },
+    });
+
+    const verify = await request(app)
+      .post("/api/auth/passkey/signup/verify")
+      .send({
+        email: "atomic@x.com",
+        name: "Atom",
+        nickname: "iPhone",
+        response: {
+          response: { clientDataJSON: buildClientDataJSON("ch-flow") },
+        },
+      });
+    expect(verify.status).toBe(201);
+    expect(verify.body.token).toBeDefined();
+    expect(verify.body.user.email).toBe("atomic@x.com");
+
+    const u = await User.findOne({ email: "atomic@x.com" });
+    expect(u).toBeDefined();
+    expect(u.hasPasskeys).toBe(true);
+    expect(u.password).toBeUndefined();
+
+    const pk = await Passkey.findOne({ credentialId: "cred-atomic" });
+    expect(pk).toBeDefined();
+    expect(pk.nickname).toBe("iPhone");
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 
 import articleRoutes from "./routes/article.routes";
 import authRoutes from "./routes/auth.routes";
+import passkeyRoutes from "./routes/passkey.routes";
 import userRoutes from "./routes/user.routes";
 import newsletterRoutes from "./routes/newsletter.routes";
 import chatRoutes from "./routes/chat.routes";
@@ -141,6 +142,8 @@ app.get("/health", (_req: Request, res: Response) => {
 
 app.use("/api/comments", commentRoutes);
 app.use("/api/articles", articleRoutes);
+// Mount passkey routes BEFORE generic /api/auth so the more specific prefix is matched first.
+app.use("/api/auth/passkey", passkeyRoutes);
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/chat", chatRoutes);

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,23 +1,8 @@
 import { Request, Response } from "express";
-import User, { IUser } from "../models/user.model";
+import User from "../models/user.model";
 import bcrypt from "bcrypt";
-import jwt from "jsonwebtoken";
 import crypto from "crypto";
-
-const JWT_SECRET = process.env.JWT_SECRET || "your_jwt_secret";
-const JWT_EXPIRES_IN = "72h"; // 3 days
-
-/**
- * Generate a JWT token for the user
- *
- * @param user The user object
- * @return The generated JWT token
- */
-const generateToken = (user: IUser) => {
-  return jwt.sign({ id: user._id, email: user.email }, JWT_SECRET, {
-    expiresIn: JWT_EXPIRES_IN,
-  });
-};
+import { signJwt } from "../services/auth-token.service";
 
 /**
  * Register a new user
@@ -27,6 +12,8 @@ const generateToken = (user: IUser) => {
  */
 export const register = async (req: Request, res: Response) => {
   const { email, password, name } = req.body;
+  if (!email || !password)
+    return res.status(400).json({ error: "Email and password are required" });
   try {
     const existingUser = await User.findOne({ email });
     if (existingUser)
@@ -45,7 +32,7 @@ export const register = async (req: Request, res: Response) => {
     });
 
     await user.save();
-    const token = generateToken(user);
+    const token = signJwt(user);
 
     res.setHeader("Authorization", token);
     return res.status(201).json({
@@ -75,10 +62,17 @@ export const login = async (req: Request, res: Response) => {
     const user = await User.findOne({ email });
     if (!user) return res.status(400).json({ error: "Invalid credentials" });
 
+    if (!user.password) {
+      return res.status(400).json({
+        error:
+          'This account uses passkey sign-in. Use "Sign in with a passkey" or reset your password to set one.',
+      });
+    }
+
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) return res.status(400).json({ error: "Invalid credentials" });
 
-    const token = generateToken(user);
+    const token = signJwt(user);
     res.setHeader("Authorization", token);
 
     return res.json({
@@ -148,7 +142,8 @@ export const resetPasswordRequest = async (req: Request, res: Response) => {
 };
 
 /**
- * Confirm reset password - update the user's password
+ * Confirm reset password - update the user's password. Doubles as
+ * "set initial password" for passkey-only accounts that lose all devices.
  *
  * @param req The request object containing email, token, and new password
  * @param res The response object to send the status of the password reset

--- a/backend/src/controllers/passkey.controller.ts
+++ b/backend/src/controllers/passkey.controller.ts
@@ -1,0 +1,534 @@
+import { Request, Response } from "express";
+import crypto from "crypto";
+import User from "../models/user.model";
+import Passkey from "../models/passkey.model";
+import WebAuthnChallenge from "../models/webauthn-challenge.model";
+import {
+  RP_ID,
+  RP_NAME,
+  RP_ORIGINS,
+  CHALLENGE_TTL_MS,
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from "../services/webauthn.service";
+import { signJwt } from "../services/auth-token.service";
+
+// Auth middleware decorates req via `(req as any).user = { id, email }`.
+const getAuth = (req: Request): { id: string; email: string } | undefined =>
+  (req as any).user;
+
+const expiresAt = () => new Date(Date.now() + CHALLENGE_TTL_MS);
+
+/**
+ * Begin passkey registration for a logged-in user.
+ *
+ * @param req Authenticated request
+ * @param res Response with PublicKeyCredentialCreationOptionsJSON
+ */
+export const beginRegistration = async (req: Request, res: Response) => {
+  try {
+    const userId = getAuth(req)?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthenticated" });
+
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const existing = await Passkey.find({ userId: user._id });
+
+    const options = await generateRegistrationOptions({
+      rpName: RP_NAME,
+      rpID: RP_ID,
+      userID: Buffer.from(String(user._id)),
+      userName: user.email,
+      userDisplayName: user.name || user.email,
+      attestationType: "none",
+      excludeCredentials: existing.map((p) => ({
+        id: p.credentialId,
+        transports: p.transports,
+      })),
+      authenticatorSelection: {
+        residentKey: "preferred",
+        userVerification: "preferred",
+      },
+    });
+
+    await WebAuthnChallenge.create({
+      challenge: options.challenge,
+      type: "registration",
+      userId: user._id,
+      expiresAt: expiresAt(),
+    });
+
+    return res.json(options);
+  } catch (error) {
+    console.error("Error in passkey registration begin:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Verify and persist a passkey registration response.
+ */
+export const verifyRegistration = async (req: Request, res: Response) => {
+  try {
+    const userId = getAuth(req)?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthenticated" });
+
+    const { response, nickname } = req.body || {};
+    if (!response) return res.status(400).json({ error: "Missing response" });
+
+    const expectedChallenge = response.response?.clientDataJSON
+      ? JSON.parse(
+          Buffer.from(response.response.clientDataJSON, "base64url").toString(
+            "utf8",
+          ),
+        ).challenge
+      : null;
+
+    if (!expectedChallenge)
+      return res.status(400).json({ error: "Missing challenge in response" });
+
+    const challengeRow = await WebAuthnChallenge.findOne({
+      challenge: expectedChallenge,
+      type: "registration",
+      userId,
+    });
+    if (!challengeRow)
+      return res.status(400).json({ error: "Challenge not found" });
+    if (challengeRow.expiresAt.getTime() < Date.now()) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Challenge expired" });
+    }
+
+    const verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: RP_ORIGINS,
+      expectedRPID: RP_ID,
+      requireUserVerification: false,
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Verification failed" });
+    }
+
+    const info: any = verification.registrationInfo;
+    // SimpleWebAuthn returns either a flat shape (older) or a nested
+    // `credential` object (v11+). Normalize.
+    const cred = info.credential || info;
+    const credentialID: string | Uint8Array = cred.id ?? info.credentialID;
+    const credentialPublicKey: Uint8Array =
+      cred.publicKey ?? info.credentialPublicKey;
+    const counter: number = cred.counter ?? info.counter ?? 0;
+    const credentialDeviceType: "singleDevice" | "multiDevice" =
+      info.credentialDeviceType || "singleDevice";
+    const credentialBackedUp: boolean = !!info.credentialBackedUp;
+    const aaguid: string | undefined = info.aaguid;
+
+    const credentialIdString =
+      typeof credentialID === "string"
+        ? credentialID
+        : Buffer.from(credentialID).toString("base64url");
+
+    const user = await User.findById(userId);
+    if (!user) {
+      await challengeRow.deleteOne();
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const passkey = await Passkey.create({
+      userId: user._id,
+      credentialId: credentialIdString,
+      publicKey: Buffer.from(credentialPublicKey),
+      counter,
+      transports: response.response?.transports || [],
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      nickname: (nickname && String(nickname).trim()) || "Passkey",
+      aaguid,
+    });
+
+    user.hasPasskeys = true;
+    await user.save();
+    await challengeRow.deleteOne();
+
+    return res.status(201).json({
+      id: passkey._id,
+      nickname: passkey.nickname,
+      createdAt: passkey.createdAt,
+      deviceType: passkey.deviceType,
+      backedUp: passkey.backedUp,
+    });
+  } catch (error) {
+    console.error("Error in passkey registration verify:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Begin passkey authentication. Discoverable / usernameless.
+ */
+export const beginAuthentication = async (req: Request, res: Response) => {
+  try {
+    const options = await generateAuthenticationOptions({
+      rpID: RP_ID,
+      userVerification: "preferred",
+      allowCredentials: [],
+    });
+
+    await WebAuthnChallenge.create({
+      challenge: options.challenge,
+      type: "authentication",
+      expiresAt: expiresAt(),
+    });
+
+    return res.json(options);
+  } catch (error) {
+    console.error("Error in passkey authentication begin:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Verify a passkey authentication response and issue a JWT.
+ */
+export const verifyAuthentication = async (req: Request, res: Response) => {
+  try {
+    const { response } = req.body || {};
+    if (!response) return res.status(400).json({ error: "Missing response" });
+
+    const expectedChallenge = response.response?.clientDataJSON
+      ? JSON.parse(
+          Buffer.from(response.response.clientDataJSON, "base64url").toString(
+            "utf8",
+          ),
+        ).challenge
+      : null;
+    if (!expectedChallenge)
+      return res.status(400).json({ error: "Missing challenge in response" });
+
+    const challengeRow = await WebAuthnChallenge.findOne({
+      challenge: expectedChallenge,
+      type: "authentication",
+    });
+    if (!challengeRow)
+      return res.status(400).json({ error: "Challenge not found" });
+    if (challengeRow.expiresAt.getTime() < Date.now()) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Challenge expired" });
+    }
+
+    const credentialId: string = response.id;
+    if (!credentialId)
+      return res.status(400).json({ error: "Missing credential id" });
+
+    const passkey = await Passkey.findOne({ credentialId });
+    if (!passkey) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Unknown credential" });
+    }
+
+    const verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: RP_ORIGINS,
+      expectedRPID: RP_ID,
+      requireUserVerification: false,
+      credential: {
+        id: passkey.credentialId,
+        publicKey: new Uint8Array(passkey.publicKey),
+        counter: passkey.counter,
+        transports: passkey.transports as any,
+      },
+    });
+
+    if (!verification.verified) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Verification failed" });
+    }
+
+    const newCounter = verification.authenticationInfo?.newCounter ?? 0;
+    passkey.counter = newCounter;
+    passkey.lastUsedAt = new Date();
+    await passkey.save();
+    await challengeRow.deleteOne();
+
+    const user = await User.findById(passkey.userId);
+    if (!user) return res.status(400).json({ error: "Owning user not found" });
+
+    const token = signJwt(user);
+    res.setHeader("Authorization", token);
+
+    return res.json({
+      user: {
+        id: user._id,
+        email: user.email,
+        name: user.name,
+        isVerified: user.isVerified,
+      },
+      token,
+    });
+  } catch (error) {
+    console.error("Error in passkey authentication verify:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Begin passkey-only signup. Does NOT create the user yet — the User row
+ * is materialized on /signup/verify after the WebAuthn ceremony succeeds.
+ * Email + name are pinned to the challenge row so an abandoned ceremony
+ * leaves no orphan account.
+ */
+export const beginSignup = async (req: Request, res: Response) => {
+  try {
+    const { email, name } = req.body || {};
+    if (!email) return res.status(400).json({ error: "Email is required" });
+
+    const existing = await User.findOne({ email });
+    if (existing) return res.status(400).json({ error: "User already exists" });
+
+    // Use a stable random userHandle so abandoned ceremonies don't leak email
+    // bytes into the authenticator's resident credential metadata.
+    const userHandle = crypto.randomBytes(32);
+
+    const options = await generateRegistrationOptions({
+      rpName: RP_NAME,
+      rpID: RP_ID,
+      userID: userHandle,
+      userName: email,
+      userDisplayName: name || email,
+      attestationType: "none",
+      authenticatorSelection: {
+        residentKey: "preferred",
+        userVerification: "preferred",
+      },
+    });
+
+    await WebAuthnChallenge.create({
+      challenge: options.challenge,
+      type: "registration",
+      // No userId — user does not exist yet. email is the link.
+      email,
+      expiresAt: expiresAt(),
+    });
+
+    return res.json(options);
+  } catch (error) {
+    console.error("Error in passkey signup begin:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Verify passkey-only signup, materialize the user, attach the credential,
+ * issue JWT.
+ */
+export const verifySignup = async (req: Request, res: Response) => {
+  try {
+    const { email, response, nickname, name } = req.body || {};
+    if (!email || !response)
+      return res.status(400).json({ error: "Missing email or response" });
+
+    const expectedChallenge = response.response?.clientDataJSON
+      ? JSON.parse(
+          Buffer.from(response.response.clientDataJSON, "base64url").toString(
+            "utf8",
+          ),
+        ).challenge
+      : null;
+    if (!expectedChallenge)
+      return res.status(400).json({ error: "Missing challenge in response" });
+
+    // Find the pending signup challenge by challenge + email — no user exists yet.
+    const challengeRow = await WebAuthnChallenge.findOne({
+      challenge: expectedChallenge,
+      type: "registration",
+      email,
+    });
+    if (!challengeRow)
+      return res.status(400).json({ error: "Challenge not found" });
+    if (challengeRow.expiresAt.getTime() < Date.now()) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Challenge expired" });
+    }
+
+    const verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: RP_ORIGINS,
+      expectedRPID: RP_ID,
+      requireUserVerification: false,
+    });
+
+    if (!verification.verified || !verification.registrationInfo) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Verification failed" });
+    }
+
+    const info: any = verification.registrationInfo;
+    const cred = info.credential || info;
+    const credentialID: string | Uint8Array = cred.id ?? info.credentialID;
+    const credentialPublicKey: Uint8Array =
+      cred.publicKey ?? info.credentialPublicKey;
+    const counter: number = cred.counter ?? info.counter ?? 0;
+    const credentialDeviceType: "singleDevice" | "multiDevice" =
+      info.credentialDeviceType || "singleDevice";
+    const credentialBackedUp: boolean = !!info.credentialBackedUp;
+    const aaguid: string | undefined = info.aaguid;
+
+    const credentialIdString =
+      typeof credentialID === "string"
+        ? credentialID
+        : Buffer.from(credentialID).toString("base64url");
+
+    // Re-check for race: another caller may have created this email between
+    // /signup/begin and /signup/verify. If so, refuse rather than overwrite.
+    const collision = await User.findOne({ email });
+    if (collision) {
+      await challengeRow.deleteOne();
+      return res.status(400).json({ error: "Email already registered" });
+    }
+
+    const verificationToken = crypto.randomBytes(20).toString("hex");
+    const user = new User({
+      email,
+      name,
+      isVerified: false,
+      verificationToken,
+      hasPasskeys: true,
+      favorites: [],
+    });
+    await user.save();
+
+    try {
+      await Passkey.create({
+        userId: user._id,
+        credentialId: credentialIdString,
+        publicKey: Buffer.from(credentialPublicKey),
+        counter,
+        transports: response.response?.transports || [],
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+        nickname: (nickname && String(nickname).trim()) || "Passkey",
+        aaguid,
+      });
+    } catch (e) {
+      // If passkey persistence fails (e.g. duplicate credentialId), unwind
+      // the user we just created so we don't leave an orphan.
+      await user.deleteOne();
+      await challengeRow.deleteOne();
+      throw e;
+    }
+
+    await challengeRow.deleteOne();
+
+    const token = signJwt(user);
+    res.setHeader("Authorization", token);
+
+    return res.status(201).json({
+      user: {
+        id: user._id,
+        email: user.email,
+        name: user.name,
+        isVerified: user.isVerified,
+      },
+      token,
+    });
+  } catch (error) {
+    console.error("Error in passkey signup verify:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * List the caller's passkeys.
+ */
+export const listPasskeys = async (req: Request, res: Response) => {
+  try {
+    const userId = getAuth(req)?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthenticated" });
+
+    const passkeys = await Passkey.find({ userId }).sort({ createdAt: -1 });
+    return res.json(
+      passkeys.map((p) => ({
+        id: p._id,
+        nickname: p.nickname,
+        createdAt: p.createdAt,
+        lastUsedAt: p.lastUsedAt,
+        deviceType: p.deviceType,
+        backedUp: p.backedUp,
+      })),
+    );
+  } catch (error) {
+    console.error("Error listing passkeys:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Rename a passkey.
+ */
+export const renamePasskey = async (req: Request, res: Response) => {
+  try {
+    const userId = getAuth(req)?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthenticated" });
+
+    const { id } = req.params;
+    const { nickname } = req.body || {};
+    if (!nickname || !String(nickname).trim())
+      return res.status(400).json({ error: "Nickname is required" });
+
+    const passkey = await Passkey.findOne({ _id: id, userId });
+    if (!passkey) return res.status(404).json({ error: "Passkey not found" });
+
+    passkey.nickname = String(nickname).trim().slice(0, 64);
+    await passkey.save();
+
+    return res.json({ id: passkey._id, nickname: passkey.nickname });
+  } catch (error) {
+    console.error("Error renaming passkey:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Delete a passkey. Refuses if it would orphan the account
+ * (no password, last passkey).
+ */
+export const deletePasskey = async (req: Request, res: Response) => {
+  try {
+    const userId = getAuth(req)?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthenticated" });
+
+    const { id } = req.params;
+
+    const passkey = await Passkey.findOne({ _id: id, userId });
+    if (!passkey) return res.status(404).json({ error: "Passkey not found" });
+
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const remaining = await Passkey.countDocuments({ userId });
+    if (remaining <= 1 && !user.password) {
+      return res.status(400).json({
+        error:
+          "Cannot delete your last passkey while no password is set. Set a password first via the reset flow, then delete.",
+      });
+    }
+
+    await passkey.deleteOne();
+    if (remaining <= 1) {
+      user.hasPasskeys = false;
+      await user.save();
+    }
+
+    return res.json({ ok: true });
+  } catch (error) {
+    console.error("Error deleting passkey:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};

--- a/backend/src/models/passkey.model.ts
+++ b/backend/src/models/passkey.model.ts
@@ -1,0 +1,100 @@
+import mongoose, { Schema, Document, Types } from "mongoose";
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Passkey:
+ *       type: object
+ *       required:
+ *         - userId
+ *         - credentialId
+ *         - publicKey
+ *         - counter
+ *         - nickname
+ *       properties:
+ *         _id:
+ *           type: string
+ *         userId:
+ *           type: string
+ *           description: Owning User _id
+ *         credentialId:
+ *           type: string
+ *           description: Base64URL-encoded credential identifier (unique)
+ *         counter:
+ *           type: integer
+ *           description: Authenticator signature counter
+ *         transports:
+ *           type: array
+ *           items:
+ *             type: string
+ *         deviceType:
+ *           type: string
+ *           enum: [singleDevice, multiDevice]
+ *         backedUp:
+ *           type: boolean
+ *         nickname:
+ *           type: string
+ *         aaguid:
+ *           type: string
+ *         lastUsedAt:
+ *           type: string
+ *           format: date-time
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ */
+
+export type PasskeyTransport =
+  | "ble"
+  | "cable"
+  | "hybrid"
+  | "internal"
+  | "nfc"
+  | "smart-card"
+  | "usb";
+
+export interface IPasskey extends Document {
+  userId: Types.ObjectId;
+  credentialId: string; // base64url
+  publicKey: Buffer;
+  counter: number;
+  transports?: PasskeyTransport[];
+  deviceType: "singleDevice" | "multiDevice";
+  backedUp: boolean;
+  nickname: string;
+  aaguid?: string;
+  lastUsedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const PasskeySchema: Schema = new Schema(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    credentialId: { type: String, required: true, unique: true, index: true },
+    publicKey: { type: Buffer, required: true },
+    counter: { type: Number, required: true, default: 0 },
+    transports: [{ type: String }],
+    deviceType: {
+      type: String,
+      enum: ["singleDevice", "multiDevice"],
+      default: "singleDevice",
+    },
+    backedUp: { type: Boolean, default: false },
+    nickname: { type: String, required: true, default: "Passkey" },
+    aaguid: { type: String },
+    lastUsedAt: { type: Date },
+  },
+  { timestamps: true },
+);
+
+export default mongoose.model<IPasskey>("Passkey", PasskeySchema);

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -8,7 +8,6 @@ import mongoose, { Schema, Document } from "mongoose";
  *       type: object
  *       required:
  *         - email
- *         - password
  *       properties:
  *         _id:
  *           type: string
@@ -19,7 +18,7 @@ import mongoose, { Schema, Document } from "mongoose";
  *           description: User's email address, unique identifier
  *         password:
  *           type: string
- *           description: Hashed user password
+ *           description: Hashed user password (optional — accounts may be passkey-only)
  *         name:
  *           type: string
  *           description: User's full name (optional)
@@ -33,6 +32,10 @@ import mongoose, { Schema, Document } from "mongoose";
  *         resetPasswordToken:
  *           type: string
  *           description: Token used to reset user's password (temporary)
+ *         hasPasskeys:
+ *           type: boolean
+ *           description: Denormalized flag indicating the user has at least one registered passkey
+ *           default: false
  *         favorites:
  *           type: array
  *           description: Array of favorited article IDs
@@ -50,25 +53,41 @@ import mongoose, { Schema, Document } from "mongoose";
 
 export interface IUser extends Document {
   email: string;
-  password: string;
+  password?: string;
   name?: string;
   isVerified: boolean;
   verificationToken?: string;
   resetPasswordToken?: string;
+  hasPasskeys?: boolean;
   favorites: string[]; // Array of Article IDs
 }
 
 const UserSchema: Schema = new Schema(
   {
     email: { type: String, required: true },
-    password: { type: String, required: true },
+    password: { type: String, required: false },
     name: { type: String },
     isVerified: { type: Boolean, default: false },
     verificationToken: { type: String },
     resetPasswordToken: { type: String },
+    hasPasskeys: { type: Boolean, default: false },
     favorites: [{ type: String }],
   },
   { timestamps: true },
 );
+
+// Belt-and-suspenders: a user must always have at least one credential —
+// a password or a passkey. Prevents accidental orphan accounts.
+UserSchema.pre("save", function (next) {
+  const doc = this as unknown as IUser;
+  if (!doc.password && !doc.hasPasskeys) {
+    return next(
+      new Error(
+        "User must have at least one credential (password or passkey).",
+      ),
+    );
+  }
+  next();
+});
 
 export default mongoose.model<IUser>("User", UserSchema);

--- a/backend/src/models/webauthn-challenge.model.ts
+++ b/backend/src/models/webauthn-challenge.model.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Document, Types } from "mongoose";
+
+export type WebAuthnChallengeType = "registration" | "authentication";
+
+export interface IWebAuthnChallenge extends Document {
+  challenge: string; // base64url
+  type: WebAuthnChallengeType;
+  userId?: Types.ObjectId;
+  email?: string; // for passkey-only signup before user exists
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const WebAuthnChallengeSchema: Schema = new Schema(
+  {
+    challenge: { type: String, required: true, unique: true, index: true },
+    type: {
+      type: String,
+      enum: ["registration", "authentication"],
+      required: true,
+    },
+    userId: { type: Schema.Types.ObjectId, ref: "User" },
+    email: { type: String },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true },
+);
+
+// Mongo TTL: rows are removed automatically when expiresAt passes.
+WebAuthnChallengeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export default mongoose.model<IWebAuthnChallenge>(
+  "WebAuthnChallenge",
+  WebAuthnChallengeSchema,
+);

--- a/backend/src/routes/passkey.routes.ts
+++ b/backend/src/routes/passkey.routes.ts
@@ -1,0 +1,189 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import {
+  beginRegistration,
+  verifyRegistration,
+  beginAuthentication,
+  verifyAuthentication,
+  beginSignup,
+  verifySignup,
+  listPasskeys,
+  renamePasskey,
+  deletePasskey,
+} from "../controllers/passkey.controller";
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Passkeys
+ *     description: WebAuthn / FIDO2 passkey registration and authentication
+ */
+
+/**
+ * @swagger
+ * /api/auth/passkey/register/begin:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Begin passkey registration for the authenticated user
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: PublicKeyCredentialCreationOptionsJSON
+ *       401:
+ *         description: Unauthenticated
+ */
+router.post("/register/begin", authenticate, beginRegistration);
+
+/**
+ * @swagger
+ * /api/auth/passkey/register/verify:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Verify a passkey registration response and persist the credential
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       201:
+ *         description: Passkey registered
+ *       400:
+ *         description: Verification failed
+ */
+router.post("/register/verify", authenticate, verifyRegistration);
+
+/**
+ * @swagger
+ * /api/auth/passkey/authenticate/begin:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Begin discoverable passkey authentication (usernameless)
+ *     responses:
+ *       200:
+ *         description: PublicKeyCredentialRequestOptionsJSON
+ */
+router.post("/authenticate/begin", beginAuthentication);
+
+/**
+ * @swagger
+ * /api/auth/passkey/authenticate/verify:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Verify a passkey authentication response and issue a JWT
+ *     responses:
+ *       200:
+ *         description: User and JWT
+ *       400:
+ *         description: Verification failed
+ */
+router.post("/authenticate/verify", verifyAuthentication);
+
+/**
+ * @swagger
+ * /api/auth/passkey/signup/begin:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Begin passkey-only signup (creates a user without a password)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email]
+ *             properties:
+ *               email: { type: string, format: email }
+ *               name: { type: string }
+ *     responses:
+ *       200:
+ *         description: PublicKeyCredentialCreationOptionsJSON
+ *       400:
+ *         description: User already exists or invalid input
+ */
+router.post("/signup/begin", beginSignup);
+
+/**
+ * @swagger
+ * /api/auth/passkey/signup/verify:
+ *   post:
+ *     tags: [Passkeys]
+ *     summary: Verify passkey signup, attach credential, return JWT
+ *     responses:
+ *       201:
+ *         description: User and JWT
+ *       400:
+ *         description: Verification failed
+ */
+router.post("/signup/verify", verifySignup);
+
+/**
+ * @swagger
+ * /api/auth/passkey:
+ *   get:
+ *     tags: [Passkeys]
+ *     summary: List the caller's passkeys
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of passkeys
+ *       401:
+ *         description: Unauthenticated
+ */
+router.get("/", authenticate, listPasskeys);
+
+/**
+ * @swagger
+ * /api/auth/passkey/{id}:
+ *   patch:
+ *     tags: [Passkeys]
+ *     summary: Rename a passkey
+ *     security:
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [nickname]
+ *             properties:
+ *               nickname: { type: string }
+ *     responses:
+ *       200:
+ *         description: Updated passkey
+ *       404:
+ *         description: Not found
+ */
+router.patch("/:id", authenticate, renamePasskey);
+
+/**
+ * @swagger
+ * /api/auth/passkey/{id}:
+ *   delete:
+ *     tags: [Passkeys]
+ *     summary: Delete a passkey
+ *     security:
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Deleted
+ *       400:
+ *         description: Cannot delete last passkey when no password is set
+ *       404:
+ *         description: Not found
+ */
+router.delete("/:id", authenticate, deletePasskey);
+
+export default router;

--- a/backend/src/services/auth-token.service.ts
+++ b/backend/src/services/auth-token.service.ts
@@ -1,0 +1,15 @@
+import jwt from "jsonwebtoken";
+import { IUser } from "../models/user.model";
+
+const JWT_SECRET = process.env.JWT_SECRET || "your_jwt_secret";
+const JWT_EXPIRES_IN = "72h";
+
+/**
+ * Sign a JWT for the given user. Single source of truth for both
+ * password-based and passkey-based authentication paths.
+ */
+export const signJwt = (user: IUser): string => {
+  return jwt.sign({ id: user._id, email: user.email }, JWT_SECRET, {
+    expiresIn: JWT_EXPIRES_IN,
+  });
+};

--- a/backend/src/services/webauthn.service.ts
+++ b/backend/src/services/webauthn.service.ts
@@ -1,0 +1,52 @@
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from "@simplewebauthn/server";
+import type {
+  GenerateRegistrationOptionsOpts,
+  GenerateAuthenticationOptionsOpts,
+  VerifyRegistrationResponseOpts,
+  VerifyAuthenticationResponseOpts,
+} from "@simplewebauthn/server";
+
+/**
+ * Relying Party (RP) configuration. RP_ID must be the *frontend* apex domain
+ * (eTLD+1) — not the backend's host. WebAuthn binds credentials to the page
+ * that runs navigator.credentials.create/get, which is the frontend.
+ *
+ * Production: synthoraai.vercel.app (vercel.app is on the Public Suffix List,
+ * so the subdomain itself is the registrable domain).
+ * Dev: localhost.
+ */
+export const RP_ID = process.env.RP_ID || "localhost";
+export const RP_NAME = process.env.RP_NAME || "SynthoraAI";
+
+/**
+ * Comma-separated list of allowed full origins. The library accepts an array
+ * for `expectedOrigin`, which prevents sibling subdomains from completing a
+ * ceremony.
+ */
+export const RP_ORIGINS: string[] = (
+  process.env.RP_ORIGIN || "http://localhost:3000,https://synthoraai.vercel.app"
+)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export const CHALLENGE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+};
+
+export type {
+  GenerateRegistrationOptionsOpts,
+  GenerateAuthenticationOptionsOpts,
+  VerifyRegistrationResponseOpts,
+  VerifyAuthenticationResponseOpts,
+};

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -8,7 +8,8 @@ This app uses the Next.js Pages Router, not the App Router.
 - Shared UI and most logic live under `components/`.
 - Data access lives under `services/`.
 - Styling is mostly global CSS and `styled-jsx`, not a Tailwind-first design system.
-- The heaviest and most fragile surfaces are `pages/home.tsx`, `pages/articles/[id].tsx`, `pages/ai_chat.tsx`, auth pages, favorites, and translation/theme behavior.
+- The heaviest and most fragile surfaces are `pages/home.tsx`, `pages/articles/[id].tsx`, `pages/ai_chat.tsx`, auth pages (`pages/auth/*`, `pages/account/passkeys.tsx`), favorites, and translation/theme behavior.
+- Passkey UI is gated by `isPasskeySupported()` from `services/api.ts` — buttons render only after client-side hydration (SSR returns false). Don't move the check into module top-level or it'll break SSR.
 
 ## Guardrails
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -66,8 +66,9 @@ flowchart LR
     Landing[Landing / Home] --> Detail[Article Detail]
     Detail --> Related[Related Articles]
     Landing --> Search[Search Results]
-    Landing --> Auth[Login / Register]
+    Landing --> Auth[Login / Register / Passkey sign-in]
     Auth --> Profile[Profile / Favorites]
+    Auth --> Passkeys["Manage Passkeys (/account/passkeys)"]
     Landing --> Newsletter[Newsletter Signup]
 ```
 
@@ -166,6 +167,14 @@ A high-level look at the project structure:
 - The `/ai_chat` page provides a full-featured conversational interface with multiple conversations, local storage persistence, and real-time SSE streaming.
 - Users can edit any previously sent message by clicking the pencil icon. Editing truncates the conversation at that point (removing all later messages) and re-sends with only the preceding history, effectively branching the conversation.
 - Keyboard shortcuts: Enter to submit the edit, Escape to cancel. The edit UI adapts to both desktop and mobile viewports.
+
+6. **Passkey (WebAuthn / FIDO2) Sign-In**
+
+- The login page exposes a "Sign in with a passkey" button when `window.PublicKeyCredential` is available — discoverable / usernameless flow, no email needed.
+- The register page offers "Sign up with a passkey instead" so brand-new users can create an account with no password at all.
+- `/account/passkeys` (linked from the auth dropdown when logged in) lets users add, rename, and delete passkeys. Multiple passkeys per account are supported (phone, laptop, hardware key).
+- Passkey calls go through `services/api.ts` (`loginWithPasskey`, `signupWithPasskey`, `registerPasskey`, `listPasskeys`, `renamePasskey`, `deletePasskey`) and dynamically import `@simplewebauthn/browser` to keep the lib out of the SSR bundle.
+- Both password and passkey paths issue the same JWT and store it as `localStorage["token"]`, so existing auth-aware components don't change.
 
 ---
 

--- a/frontend/components/AuthDropdown.tsx
+++ b/frontend/components/AuthDropdown.tsx
@@ -101,7 +101,12 @@ export default function AuthDropdown({
   };
 
   // Highlight icon when on any auth route
-  const authPaths = ["/auth/login", "/auth/register", "/auth/reset-password"];
+  const authPaths = [
+    "/auth/login",
+    "/auth/register",
+    "/auth/reset-password",
+    "/account/passkeys",
+  ];
   const isAuthRoute = authPaths.includes(router.pathname);
 
   return (
@@ -120,12 +125,26 @@ export default function AuthDropdown({
         <div className="auth-dropdown">
           <div className="auth-section">
             {isLoggedIn ? (
-              <button
-                className="auth-option logout-option"
-                onClick={handleLogout}
-              >
-                Logout
-              </button>
+              <>
+                <Link href="/account/passkeys" legacyBehavior>
+                  <a
+                    className={`auth-option${
+                      router.pathname === "/account/passkeys"
+                        ? " active-auth-option"
+                        : ""
+                    }`}
+                    onClick={toggle}
+                  >
+                    Manage Passkeys
+                  </a>
+                </Link>
+                <button
+                  className="auth-option logout-option"
+                  onClick={handleLogout}
+                >
+                  Logout
+                </button>
+              </>
             ) : (
               <>
                 <Link href="/auth/login" legacyBehavior>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^11.0.0",
     "@vercel/analytics": "^1.5.0",
     "framer-motion": "^12.12.1",
     "lucide-react": "^0.477.0",

--- a/frontend/pages/account/passkeys.tsx
+++ b/frontend/pages/account/passkeys.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import Link from "next/link";
+import { MdKey, MdDelete, MdEdit, MdCheck, MdClose } from "react-icons/md";
+import {
+  isPasskeySupported,
+  listPasskeys,
+  registerPasskey,
+  renamePasskey,
+  deletePasskey,
+  PasskeySummary,
+} from "../../services/api";
+import { toast } from "react-toastify";
+
+export default function PasskeysPage() {
+  const router = useRouter();
+  const [supported, setSupported] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [adding, setAdding] = useState<boolean>(false);
+  const [passkeys, setPasskeys] = useState<PasskeySummary[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingValue, setEditingValue] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
+  const refresh = async () => {
+    try {
+      const data = await listPasskeys();
+      setPasskeys(data);
+    } catch (err: any) {
+      if (
+        typeof err?.message === "string" &&
+        /token|unauth/i.test(err.message)
+      ) {
+        router.replace("/auth/login");
+        return;
+      }
+      setError(err.message || "Failed to load passkeys");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setSupported(isPasskeySupported());
+    if (typeof window === "undefined") return;
+    if (!localStorage.getItem("token")) {
+      router.replace("/auth/login");
+      return;
+    }
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleAdd = async () => {
+    setError("");
+    setAdding(true);
+    try {
+      const defaultName =
+        typeof navigator !== "undefined" &&
+        /iphone|ipad|ipod/i.test(navigator.userAgent)
+          ? "iPhone / iPad"
+          : /android/i.test(navigator?.userAgent || "")
+            ? "Android device"
+            : /mac/i.test(navigator?.userAgent || "")
+              ? "Mac"
+              : /windows/i.test(navigator?.userAgent || "")
+                ? "Windows device"
+                : "Passkey";
+      await registerPasskey(defaultName);
+      toast("Passkey added 🔑");
+      await refresh();
+    } catch (err: any) {
+      if (err?.name === "NotAllowedError") return;
+      setError(err.message || "Could not add passkey");
+      toast("Could not add passkey.");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRename = async (id: string) => {
+    if (!editingValue.trim()) return;
+    try {
+      await renamePasskey(id, editingValue.trim());
+      setEditingId(null);
+      setEditingValue("");
+      toast("Renamed ✏️");
+      await refresh();
+    } catch (err: any) {
+      setError(err.message || "Could not rename");
+      toast("Could not rename passkey.");
+    }
+  };
+
+  const handleDelete = async (id: string, nickname: string) => {
+    if (
+      !confirm(
+        `Delete "${nickname}"? You will not be able to sign in with this device anymore.`,
+      )
+    )
+      return;
+    try {
+      await deletePasskey(id);
+      toast("Passkey removed 🗑️");
+      await refresh();
+    } catch (err: any) {
+      setError(err.message || "Could not delete");
+      toast(err.message || "Could not delete passkey.");
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>SynthoraAI - Manage Passkeys</title>
+      </Head>
+      <div className="login-container" style={{ maxWidth: 640 }}>
+        <h1 className="login-title">Passkeys 🔑</h1>
+        <p
+          className="subtitle"
+          style={{ textAlign: "center", marginBottom: "1.5rem" }}
+        >
+          Sign in faster with Face ID, Touch ID, Windows Hello, or a hardware
+          key — no password needed.
+        </p>
+
+        {!supported && (
+          <p className="error-msg">
+            Your browser does not support passkeys. Try Chrome, Safari, or Edge
+            on a recent OS.
+          </p>
+        )}
+        {error && <p className="error-msg">{error}</p>}
+
+        <button
+          type="button"
+          className="btn submit-btn"
+          onClick={handleAdd}
+          disabled={!supported || adding}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "0.5rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          <MdKey size={20} />
+          {adding ? "Waiting…" : "Add a passkey"}
+        </button>
+
+        {loading ? (
+          <p style={{ textAlign: "center", color: "var(--muted-text, #888)" }}>
+            Loading passkeys…
+          </p>
+        ) : passkeys.length === 0 ? (
+          <p style={{ textAlign: "center", color: "var(--muted-text, #888)" }}>
+            You haven't added any passkeys yet.
+          </p>
+        ) : (
+          <ul
+            style={{
+              listStyle: "none",
+              padding: 0,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.75rem",
+            }}
+          >
+            {passkeys.map((pk) => (
+              <li
+                key={pk.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "0.85rem 1rem",
+                  borderRadius: 8,
+                  border:
+                    "1px solid var(--border-color, rgba(127,127,127,0.25))",
+                  gap: "0.75rem",
+                  flexWrap: "wrap",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                >
+                  <MdKey size={22} aria-hidden />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    {editingId === pk.id ? (
+                      <input
+                        autoFocus
+                        className="form-input"
+                        value={editingValue}
+                        onChange={(e) => setEditingValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleRename(pk.id);
+                          if (e.key === "Escape") {
+                            setEditingId(null);
+                            setEditingValue("");
+                          }
+                        }}
+                        maxLength={64}
+                        style={{ width: "100%" }}
+                      />
+                    ) : (
+                      <strong
+                        style={{
+                          display: "block",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {pk.nickname}
+                      </strong>
+                    )}
+                    <small style={{ color: "var(--muted-text, #888)" }}>
+                      Added {new Date(pk.createdAt).toLocaleDateString()}
+                      {pk.lastUsedAt &&
+                        ` · last used ${new Date(pk.lastUsedAt).toLocaleDateString()}`}
+                      {pk.deviceType === "multiDevice" && pk.backedUp
+                        ? " · synced"
+                        : ""}
+                    </small>
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 6 }}>
+                  {editingId === pk.id ? (
+                    <>
+                      <button
+                        type="button"
+                        className="btn"
+                        onClick={() => handleRename(pk.id)}
+                        aria-label="Save"
+                        style={{ padding: "0.4rem 0.6rem" }}
+                      >
+                        <MdCheck size={18} />
+                      </button>
+                      <button
+                        type="button"
+                        className="btn"
+                        onClick={() => {
+                          setEditingId(null);
+                          setEditingValue("");
+                        }}
+                        aria-label="Cancel"
+                        style={{ padding: "0.4rem 0.6rem" }}
+                      >
+                        <MdClose size={18} />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        className="btn"
+                        onClick={() => {
+                          setEditingId(pk.id);
+                          setEditingValue(pk.nickname);
+                        }}
+                        aria-label="Rename"
+                        style={{ padding: "0.4rem 0.6rem" }}
+                      >
+                        <MdEdit size={18} />
+                      </button>
+                      <button
+                        type="button"
+                        className="btn"
+                        onClick={() => handleDelete(pk.id, pk.nickname)}
+                        aria-label="Delete"
+                        style={{ padding: "0.4rem 0.6rem" }}
+                      >
+                        <MdDelete size={18} />
+                      </button>
+                    </>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="form-links" style={{ marginTop: "1.5rem" }}>
+          <p>
+            <Link href="/home" legacyBehavior>
+              <a>← Back to home</a>
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/pages/auth/login.tsx
+++ b/frontend/pages/auth/login.tsx
@@ -1,9 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import Head from "next/head";
-import { MdVisibility, MdVisibilityOff } from "react-icons/md";
-import { loginUser } from "../../services/api";
+import { MdVisibility, MdVisibilityOff, MdKey } from "react-icons/md";
+import {
+  loginUser,
+  loginWithPasskey,
+  isPasskeySupported,
+} from "../../services/api";
 import { toast } from "react-toastify";
 
 export default function Login() {
@@ -12,19 +16,42 @@ export default function Login() {
   const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [message, setMessage] = useState<string>("");
+  const [passkeySupported, setPasskeySupported] = useState<boolean>(false);
+  const [passkeyLoading, setPasskeyLoading] = useState<boolean>(false);
   const router = useRouter();
+
+  useEffect(() => {
+    setPasskeySupported(isPasskeySupported());
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
     try {
-      const data = await loginUser(email, password);
+      await loginUser(email, password);
       setMessage("");
       toast("Login successful! Redirecting to Home... 🔐");
       router.push("/home");
     } catch (err: any) {
       setError(err.message);
       toast("Could not login user. Please try again.");
+    }
+  };
+
+  const handlePasskeyLogin = async () => {
+    setError("");
+    setPasskeyLoading(true);
+    try {
+      await loginWithPasskey();
+      toast("Signed in with passkey 🔑");
+      router.push("/home");
+    } catch (err: any) {
+      // User-cancelled WebAuthn prompts surface as NotAllowedError — stay quiet.
+      if (err?.name === "NotAllowedError") return;
+      setError(err.message || "Passkey sign-in failed.");
+      toast("Could not sign in with passkey.");
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -82,6 +109,54 @@ export default function Login() {
             Login
           </button>
         </form>
+        {passkeySupported && (
+          <>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.75rem",
+                margin: "1.25rem 0",
+                color: "var(--muted-text, #888)",
+                fontSize: "0.85rem",
+              }}
+            >
+              <span
+                style={{
+                  flex: 1,
+                  height: 1,
+                  background: "currentColor",
+                  opacity: 0.3,
+                }}
+              />
+              <span>or</span>
+              <span
+                style={{
+                  flex: 1,
+                  height: 1,
+                  background: "currentColor",
+                  opacity: 0.3,
+                }}
+              />
+            </div>
+            <button
+              type="button"
+              className="btn submit-btn"
+              onClick={handlePasskeyLogin}
+              disabled={passkeyLoading}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "0.5rem",
+              }}
+              aria-label="Sign in with a passkey"
+            >
+              <MdKey size={20} />
+              {passkeyLoading ? "Waiting…" : "Sign in with a passkey"}
+            </button>
+          </>
+        )}
         <div className="form-links">
           <p>
             Don't have an account?{" "}

--- a/frontend/pages/auth/register.tsx
+++ b/frontend/pages/auth/register.tsx
@@ -1,9 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import Link from "next/link";
-import { MdVisibility, MdVisibilityOff } from "react-icons/md";
-import { registerUser } from "../../services/api";
+import { MdVisibility, MdVisibilityOff, MdKey } from "react-icons/md";
+import {
+  registerUser,
+  signupWithPasskey,
+  isPasskeySupported,
+} from "../../services/api";
 import { toast } from "react-toastify";
 
 export default function Register() {
@@ -14,7 +18,13 @@ export default function Register() {
   const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [message, setMessage] = useState<string>("");
+  const [passkeySupported, setPasskeySupported] = useState<boolean>(false);
+  const [passkeyLoading, setPasskeyLoading] = useState<boolean>(false);
   const router = useRouter();
+
+  useEffect(() => {
+    setPasskeySupported(isPasskeySupported());
+  }, []);
 
   const toggleVisibility = () => setPasswordVisible((prev) => !prev);
 
@@ -37,6 +47,26 @@ export default function Register() {
         err instanceof Error ? err.message : "An unknown error occurred",
       );
       toast("Could not register user. Please try again.");
+    }
+  };
+
+  const handlePasskeySignup = async () => {
+    setError("");
+    if (!email) {
+      setError("Enter your email above before creating a passkey account.");
+      return;
+    }
+    setPasskeyLoading(true);
+    try {
+      await signupWithPasskey(email, name || undefined);
+      toast("Account created with passkey 🔑");
+      router.push("/home");
+    } catch (err: any) {
+      if (err?.name === "NotAllowedError") return;
+      setError(err.message || "Passkey signup failed.");
+      toast("Could not create passkey account.");
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -128,6 +158,64 @@ export default function Register() {
             Register
           </button>
         </form>
+        {passkeySupported && (
+          <>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "0.75rem",
+                margin: "1.25rem 0",
+                color: "var(--muted-text, #888)",
+                fontSize: "0.85rem",
+              }}
+            >
+              <span
+                style={{
+                  flex: 1,
+                  height: 1,
+                  background: "currentColor",
+                  opacity: 0.3,
+                }}
+              />
+              <span>or skip the password</span>
+              <span
+                style={{
+                  flex: 1,
+                  height: 1,
+                  background: "currentColor",
+                  opacity: 0.3,
+                }}
+              />
+            </div>
+            <button
+              type="button"
+              className="btn submit-btn"
+              onClick={handlePasskeySignup}
+              disabled={passkeyLoading}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "0.5rem",
+              }}
+              aria-label="Sign up with a passkey"
+            >
+              <MdKey size={20} />
+              {passkeyLoading ? "Waiting…" : "Sign up with a passkey instead"}
+            </button>
+            <p
+              style={{
+                fontSize: "0.8rem",
+                color: "var(--muted-text, #888)",
+                textAlign: "center",
+                marginTop: "0.5rem",
+              }}
+            >
+              Uses Face ID, Touch ID, Windows Hello, or a hardware key.
+            </p>
+          </>
+        )}
         <div className="form-links">
           <p>
             Already have an account?{" "}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -303,6 +303,139 @@ export const loginUser = async (email: string, password: string) => {
   }
 };
 
+/* ───────────── Passkey (WebAuthn) ───────────── */
+
+/**
+ * Returns true when the current browser exposes the WebAuthn API.
+ */
+export const isPasskeySupported = (): boolean => {
+  return (
+    typeof window !== "undefined" &&
+    typeof (window as any).PublicKeyCredential !== "undefined"
+  );
+};
+
+const authHeader = (): Record<string, string> => {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  return token ? { Authorization: token } : {};
+};
+
+const postJson = async (path: string, body: any, withAuth = false) => {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(withAuth ? authHeader() : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || "Request failed. Please retry.");
+  return data;
+};
+
+/**
+ * Sign in with a passkey. Discoverable / usernameless flow.
+ * Stores the JWT in localStorage on success — exact same key as loginUser.
+ */
+export const loginWithPasskey = async () => {
+  const { startAuthentication } = await import("@simplewebauthn/browser");
+  const options = await postJson("/auth/passkey/authenticate/begin", {});
+  const response = await startAuthentication({ optionsJSON: options });
+  const data = await postJson("/auth/passkey/authenticate/verify", {
+    response,
+  });
+  if (data?.token) localStorage.setItem("token", data.token);
+  return data;
+};
+
+/**
+ * Sign up with a passkey only (no password). Creates a new account and
+ * stores the JWT.
+ */
+export const signupWithPasskey = async (
+  email: string,
+  name?: string,
+  nickname?: string,
+) => {
+  const { startRegistration } = await import("@simplewebauthn/browser");
+  const options = await postJson("/auth/passkey/signup/begin", {
+    email,
+    name,
+  });
+  const response = await startRegistration({ optionsJSON: options });
+  const data = await postJson("/auth/passkey/signup/verify", {
+    email,
+    response,
+    nickname,
+  });
+  if (data?.token) localStorage.setItem("token", data.token);
+  return data;
+};
+
+/**
+ * Add a passkey to the currently logged-in account.
+ */
+export const registerPasskey = async (nickname?: string) => {
+  const { startRegistration } = await import("@simplewebauthn/browser");
+  const options = await postJson("/auth/passkey/register/begin", {}, true);
+  const response = await startRegistration({ optionsJSON: options });
+  return postJson(
+    "/auth/passkey/register/verify",
+    { response, nickname },
+    true,
+  );
+};
+
+export interface PasskeySummary {
+  id: string;
+  nickname: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  deviceType: "singleDevice" | "multiDevice";
+  backedUp: boolean;
+}
+
+/**
+ * List the current user's passkeys.
+ */
+export const listPasskeys = async (): Promise<PasskeySummary[]> => {
+  const res = await fetch(`${BASE_URL}/auth/passkey`, {
+    headers: { ...authHeader() },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || "Failed to load passkeys");
+  return data;
+};
+
+/**
+ * Rename a passkey.
+ */
+export const renamePasskey = async (id: string, nickname: string) => {
+  const res = await fetch(`${BASE_URL}/auth/passkey/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ nickname }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || "Failed to rename passkey");
+  return data;
+};
+
+/**
+ * Delete a passkey.
+ */
+export const deletePasskey = async (id: string) => {
+  const res = await fetch(`${BASE_URL}/auth/passkey/${id}`, {
+    method: "DELETE",
+    headers: { ...authHeader() },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || "Failed to delete passkey");
+  return data;
+};
+
 /**
  * Registers a new user.
  * @param name - User's name

--- a/frontend/tests/passkey.spec.ts
+++ b/frontend/tests/passkey.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Passkey UI smoke tests.
+ *
+ * Full WebAuthn ceremonies require a Chrome DevTools Protocol Virtual
+ * Authenticator. These tests cover the deterministic UI surface — the
+ * end-to-end ceremony is exercised via manual QA (or a CDP harness in CI;
+ * see the implementation plan).
+ */
+test.describe("Passkey UI", () => {
+  test("login page exposes the passkey button when WebAuthn is available", async ({
+    page,
+  }) => {
+    await page.goto("/auth/login");
+    const btn = page.getByRole("button", { name: /sign in with a passkey/i });
+    await expect(btn).toBeVisible();
+  });
+
+  test("register page exposes the passkey signup button", async ({ page }) => {
+    await page.goto("/auth/register");
+    const btn = page.getByRole("button", {
+      name: /sign up with a passkey/i,
+    });
+    await expect(btn).toBeVisible();
+  });
+
+  test("passkey login button hides when WebAuthn is unavailable", async ({
+    page,
+  }) => {
+    // Strip WebAuthn before the page boots.
+    await page.addInitScript(() => {
+      // @ts-ignore
+      delete (window as any).PublicKeyCredential;
+    });
+    await page.goto("/auth/login");
+    const btn = page.getByRole("button", { name: /sign in with a passkey/i });
+    await expect(btn).toHaveCount(0);
+  });
+
+  test("passkey login surfaces a toast when verify fails", async ({ page }) => {
+    await page.route("**/auth/passkey/authenticate/begin", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          challenge: "Y2hhbGxlbmdl",
+          timeout: 60000,
+          rpId: "localhost",
+          allowCredentials: [],
+          userVerification: "preferred",
+        }),
+      }),
+    );
+
+    await page.goto("/auth/login");
+
+    // Force the WebAuthn API to throw a non-NotAllowedError so the catch
+    // branch surfaces an error toast (NotAllowedError is silenced).
+    await page.evaluate(() => {
+      (navigator as any).credentials = {
+        get: async () => {
+          const e: any = new Error("forced failure");
+          e.name = "InvalidStateError";
+          throw e;
+        },
+      };
+    });
+
+    await page.getByRole("button", { name: /sign in with a passkey/i }).click();
+
+    await expect(
+      page.locator(".Toastify__toast-body", {
+        hasText: /could not sign in with passkey/i,
+      }),
+    ).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@pinecone-database/pinecone": "^6.1.2",
+        "@simplewebauthn/server": "^11.0.0",
         "@vercel/node": "^5.1.10",
         "axios": "^1.2.0",
         "bcrypt": "^5.1.1",
@@ -1093,6 +1094,7 @@
       "name": "government-article-curator-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@simplewebauthn/browser": "^11.0.0",
         "@vercel/analytics": "^1.5.0",
         "framer-motion": "^12.12.1",
         "lucide-react": "^0.477.0",
@@ -5726,6 +5728,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
@@ -6753,6 +6761,12 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.0.tgz",
@@ -7260,6 +7274,73 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "optional": true
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@pinecone-database/pinecone": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-6.1.2.tgz",
@@ -7568,6 +7649,42 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-11.0.0.tgz",
+      "integrity": "sha512-KEGCStrl08QC2I561BzxqGiwoknblP6O1YW7jApdXLPtIqZ+vgJYAv8ssLCdm1wD8HGAHd49CJLkUF8X70x/pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplewebauthn/types": "^11.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-11.0.0.tgz",
+      "integrity": "sha512-zu8dxKcPiRUNSN2kmrnNOzNbRI8VaR/rL4ENCHUfC6PEE7SAAdIql9g5GBOd/wOVZolIsaZz3ccFxuGoVP0iaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^11.0.0",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-11.0.0.tgz",
+      "integrity": "sha512-b2o0wC5u2rWts31dTgBkAtSNKGX0cvL6h8QedNsKmj8O4QoLFQFR3DBVBUlpyVEhYKA+mXGUaXbcOc4JdQ3HzA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -9562,6 +9679,20 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -11005,6 +11136,57 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -18274,6 +18456,24 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.13.0",


### PR DESCRIPTION
This pull request introduces comprehensive support for passwordless authentication using WebAuthn passkeys (FIDO2) alongside traditional email/password login. The changes span backend models, configuration, documentation, and tests. The user model now supports accounts with either a password, a passkey, or both, and new endpoints and environment variables have been added for passkey management. The documentation has been updated throughout to reflect these new authentication flows and the security model. A full integration test suite for the new models and validation logic is also included.

**Authentication and Security Model Enhancements:**

* Added support for passwordless authentication via WebAuthn/FIDO2 passkeys, allowing users to create accounts with passkeys only, add passkeys to existing accounts, and manage passkeys (list, rename, delete) (`@simplewebauthn/server` dependency, new endpoints, and updated model/validator logic). [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R21) [[2]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL102-R119) [[3]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dR196-R208) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L428-R428) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L672-R681) [[6]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1653-R1679) [[7]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1926-R1984) [[8]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L6-R6) [[9]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R24) [[10]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL14-R17)
* The JWT authentication flow is unified: both password and passkey logins issue the same JWT, and the `User.password` field is now optional (enforced by a pre-save validator that requires at least one credential). [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1653-R1679) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1926-R1984) [[3]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL14-R17)

**Configuration and Environment Variables:**

* Introduced new environment variables for WebAuthn Relying Party configuration (`RP_ID`, `RP_NAME`, `RP_ORIGIN`) in backend `.env.example`, `README.md`, and architecture docs. [[1]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080R23-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R496-R504) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1879-R1881) [[4]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dR196-R208)

**Documentation Updates:**

* Updated `README.md`, `ARCHITECTURE.md`, and `CLAUDE.md` to document the new authentication flows, passkey management endpoints, model changes, and security guardrails. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L428-R428) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L672-R681) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1653-R1679) [[4]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1879-R1881) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1926-R1984) [[6]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L6-R6) [[7]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R24) [[8]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL14-R17)
* Expanded the backend API reference to include all passkey-related endpoints and clarified the security expectations for sensitive code paths. [[1]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL102-R119) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L24-R24) [[3]](diffhunk://#diff-11cca2fba0e3c1246420be768e2e9018de14582c57124f428ab050106de9118eL14-R17)

**Testing:**

* Added a new integration test suite (`passkey.model.spec.js`) that verifies model validation, credential uniqueness, and TTL index behavior for User, Passkey, and WebAuthnChallenge collections.

**Miscellaneous:**

* Added a new Playwright-related Bash command to `.claude/settings.local.json` for searching TypeScript/JavaScript/JSX/TSX files.

These changes lay the groundwork for secure, modern, and flexible authentication, supporting both traditional and passwordless user experiences.