### PR TITLE
fix(backend): raise mongodb-memory-server launchTimeout for Windows CI

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testTimeout: 60000,
+  testTimeout: 120000,
   setupFiles: ["<rootDir>/src/__tests__/jest.setup.js"],
   moduleFileExtensions: ["ts", "js", "json"],
   testMatch: [

--- a/backend/src/__tests__/passkey.model.spec.js
+++ b/backend/src/__tests__/passkey.model.spec.js
@@ -10,7 +10,11 @@ let mongoServer;
 let User, Passkey, Challenge;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
+  // Windows CI runners regularly need >10s (the lib default) to launch mongod;
+  // a too-short launchTimeout rejects here and cascades into undefined-model errors.
+  mongoServer = await MongoMemoryServer.create({
+    instance: { launchTimeout: 60000 },
+  });
   await mongoose.connect(mongoServer.getUri());
 
   // Lazy-load AFTER mongoose connect so models register on the same connection.

--- a/backend/src/__tests__/passkey.routes.spec.js
+++ b/backend/src/__tests__/passkey.routes.spec.js
@@ -27,7 +27,11 @@ let app;
 let User, Passkey;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
+  // Windows CI runners regularly need >10s (the lib default) to launch mongod;
+  // a too-short launchTimeout rejects here and cascades into undefined-model errors.
+  mongoServer = await MongoMemoryServer.create({
+    instance: { launchTimeout: 60000 },
+  });
   await mongoose.connect(mongoServer.getUri());
 
   User = require("../models/user.model").default;


### PR DESCRIPTION
## Problem

The **Backend Tests (windows-latest, 18)** CI job was failing — 17 tests across two suites (`passkey.model.spec.js`, `passkey.routes.spec.js`):

```
Instance failed to start within 10000ms
  at Timeout.<anonymous> (.../mongodb-memory-server-core/src/util/MongoInstance.ts:383:21)

TypeError: Cannot read properties of undefined (reading 'deleteMany')
TypeError: Cannot read properties of undefined (reading 'stop')
```

## Root cause

Both passkey integration specs called `MongoMemoryServer.create()` with no options, leaving the per-instance `launchTimeout` at the library default of **10000ms** (`MongoInstance.js`: `1000 * 10`). There is no `MONGOMS_` env override for this value — it is only settable via the `instance.launchTimeout` option.

On Windows GitHub Actions runners, `mongod` regularly takes longer than 10s to launch, so the launch promise rejected inside `beforeAll`. Because `beforeAll` threw, `User` / `Passkey` / `Challenge` and `mongoServer` were never assigned — hence the cascade of `undefined.deleteMany` (in `afterEach`) and `undefined.stop` (in `afterAll`) errors.

macOS/Linux runners launch fast enough to stay under 10s, which is why only the Windows job failed.

## Fix

- Pass `instance: { launchTimeout: 60000 }` to `MongoMemoryServer.create()` in both passkey specs.
- Raise jest `testTimeout` `60000 → 120000` so a genuine launch timeout surfaces with its own clear error instead of jest killing the hook first.

No production code changed — test/config only.

## Verification

Local full backend suite: **104/104 passed** (incl. both previously-failing passkey suites). Crawler (10/10) and newsletters (4/4) suites also green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)